### PR TITLE
Mixer sample buffer added channels twice

### DIFF
--- a/src/respec/Mixer.cpp
+++ b/src/respec/Mixer.cpp
@@ -66,11 +66,11 @@ void Mixer::setSpecs(Specs specs)
 
 void Mixer::clear(int length)
 {
-	m_buffer.assureSize(length * m_specs.channels * AUD_SAMPLE_SIZE(m_specs));
+	m_buffer.assureSize(length * AUD_SAMPLE_SIZE(m_specs));
 
 	m_length = length;
 
-	std::memset(m_buffer.getBuffer(), 0, length * m_specs.channels * AUD_SAMPLE_SIZE(m_specs));
+	std::memset(m_buffer.getBuffer(), 0, length * AUD_SAMPLE_SIZE(m_specs));
 }
 
 void Mixer::mix(sample_t* buffer, int start, int length, float volume)


### PR DESCRIPTION
Perhaps I'm missing something, but when I looked through the code when trying to hunt down some A/V sync issues, I noticed that channels are added twice here. (Once with `m_specs.channels *` and once more in the `AUD_SAMPLE_SIZE` macro)

This was the only place where this happens where `AUD_SAMPLE_SIZE` is used, so I guess it is a mistake?