### PR TITLE
Simplify buffer resize function

### DIFF
--- a/bindings/C/AUD_Special.cpp
+++ b/bindings/C/AUD_Special.cpp
@@ -153,7 +153,7 @@ AUD_API float* AUD_readSoundBuffer(const char* filename, float low, float high,
 		do
 		{
 			len = samplerate;
-			buffer.resize((position + len) * sizeof(float), true);
+			buffer.resize((position + len) * sizeof(float));
 			reader->read(len, eos, buffer.getBuffer() + position);
 			position += len;
 		} while(!eos);

--- a/include/util/Buffer.h
+++ b/include/util/Buffer.h
@@ -68,20 +68,16 @@ public:
 	/**
 	 * Resizes the buffer.
 	 * \param size The new size of the buffer, measured in bytes.
-	 * \param keep Whether to keep the old data. If the new buffer is smaller,
-	 *        the data at the end will be lost.
 	 */
-	void resize(int size, bool keep = false);
+	void resize(int size);
 
 	/**
 	 * Makes sure the buffer has a minimum size.
 	 * If size is >= current size, nothing will happen.
 	 * Otherwise the buffer is resized with keep as parameter.
 	 * \param size The new minimum size of the buffer, measured in bytes.
-	 * \param keep Whether to keep the old data. If the new buffer is smaller,
-	 *        the data at the end will be lost.
 	 */
-	void assureSize(int size, bool keep = false);
+	void assureSize(int size);
 };
 
 AUD_NAMESPACE_END

--- a/plugins/ffmpeg/FFMPEGReader.cpp
+++ b/plugins/ffmpeg/FFMPEGReader.cpp
@@ -97,7 +97,7 @@ int FFMPEGReader::decode(AVPacket& packet, Buffer& buffer)
 
 		if(buf_size - buf_pos < data_size)
 		{
-			buffer.resize(buf_size + data_size, true);
+			buffer.resize(buf_size + data_size);
 			buf_size += data_size;
 		}
 

--- a/src/respec/JOSResampleReader.cpp
+++ b/src/respec/JOSResampleReader.cpp
@@ -72,7 +72,7 @@ void JOSResampleReader::updateBuffer(int size, double factor, int samplesize)
 		m_cache_valid -= len;
 	}
 
-	m_buffer.assureSize((m_cache_valid + size) * samplesize, true);
+	m_buffer.assureSize((m_cache_valid + size) * samplesize);
 }
 
 #define RESAMPLE_METHOD(name, left, right) void JOSResampleReader::name(double target_factor, int length, sample_t* buffer)\

--- a/src/util/Buffer.cpp
+++ b/src/util/Buffer.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cstring>
 #include <cstdlib>
+#include <stdio.h>
 
 #define ALIGNMENT 32
 #define ALIGN(a) (a + ALIGNMENT - ((long long)a & (ALIGNMENT-1)))
@@ -46,27 +47,18 @@ int Buffer::getSize() const
 	return m_size;
 }
 
-void Buffer::resize(int size, bool keep)
+void Buffer::resize(int size)
 {
-	if(keep)
-	{
-		data_t* buffer = (data_t*) std::malloc(size + ALIGNMENT);
-
-		std::memcpy(ALIGN(buffer), ALIGN(m_buffer), std::min(size, m_size));
-
-		std::free(m_buffer);
-		m_buffer = buffer;
-	}
-	else
-		m_buffer = (data_t*) std::realloc(m_buffer, size + ALIGNMENT);
+	m_buffer = (data_t*) std::realloc(m_buffer, size + ALIGNMENT);
 
 	m_size = size;
 }
 
-void Buffer::assureSize(int size, bool keep)
+void Buffer::assureSize(int size)
 {
-	if(m_size < size)
-		resize(size, keep);
+	if(m_size < size) {
+		resize(size);
+	}
 }
 
 AUD_NAMESPACE_END

--- a/src/util/StreamBuffer.cpp
+++ b/src/util/StreamBuffer.cpp
@@ -47,7 +47,7 @@ StreamBuffer::StreamBuffer(std::shared_ptr<ISound> sound) :
 	while(!eos)
 	{
 		// increase
-		m_buffer->resize(size*sample_size, true);
+		m_buffer->resize(size*sample_size);
 
 		// read more
 		length = size-index;
@@ -57,7 +57,7 @@ StreamBuffer::StreamBuffer(std::shared_ptr<ISound> sound) :
 		index += length;
 	}
 
-	m_buffer->resize(index * sample_size, true);
+	m_buffer->resize(index * sample_size);
 }
 
 StreamBuffer::StreamBuffer(std::shared_ptr<Buffer> buffer, Specs specs) :


### PR DESCRIPTION
Also stumbled upon this when looking into A/V sync issues.

The "keep" code branch did the same thing as std::realloc.
(Unless I'm mistaken...)