### PR TITLE
Add proof of concept high resolution audio syncing

### DIFF
--- a/include/devices/SoftwareDevice.h
+++ b/include/devices/SoftwareDevice.h
@@ -31,6 +31,7 @@
 
 #include <list>
 #include <mutex>
+#include <chrono>
 
 AUD_NAMESPACE_BEGIN
 
@@ -60,6 +61,13 @@ protected:
 		SoftwareHandle& operator=(const SoftwareHandle&) = delete;
 
 	public:
+		/// The last time that the buffer position changed
+		std::chrono::time_point<std::chrono::steady_clock> t1;
+		int prev_pos = 0;
+		float offset = 0;
+		float adjust = 0;
+		bool reset_clock = true;
+
 		/// The reader source.
 		std::shared_ptr<IReader> m_reader;
 


### PR DESCRIPTION
When working with Blender, I've always thought that the `A/V Sync` option for playback was jerky and non smooth.

I took a look at it and it turns out that I was right!
There is some code in place that tries to mask it, but if you remove it, the issue become really apparent.
(Blender patch:)
```
--- a/source/blender/editors/screen/screen_ops.c
+++ b/source/blender/editors/screen/screen_ops.c
@@ -4412,14 +4412,8 @@ static int screen_animation_step(bContext *C, wmOperator *UNUSED(op), const wmEv
     else if ((scene->audio.flag & AUDIO_SYNC) && (sad->flag & ANIMPLAY_FLAG_REVERSE) == false &&
              isfinite(time = BKE_sound_sync_scene(scene_eval))) {
       double newfra = (double)time * FPS;
-
-      /* give some space here to avoid jumps */
-      if (newfra + 0.5 > scene->r.cfra && newfra - 0.5 < scene->r.cfra) {
-        scene->r.cfra++;
-      }
-      else {
-        scene->r.cfra = max_ii(scene->r.cfra, newfra + 0.5);
-      }
+      scene->r.cfra = newfra;
+      scene->r.subframe = fractf(newfra);  // TODO is this needed or nice to have?

 #ifdef PROFILE_AUDIO_SYNCH
       newfra_int = scene->r.cfra;
```

The issue is that, at least for OpenAL and SDL on my computer, the audio position query resolution is not high enough. So when asking for the current time, we will get freeze frames.

This is very apparent with big buffer sizes on the SDL backend.
With OpenAL this is not as noticeable, but it is still there to a lesser extent.
You can tell the difference in smoothness when toggling between `No Sync` and `A/V sync`.

I looked around online to see what the common approach is to solve this, and it seems like the simplest way is to have a timer running so we keep track of the time ourselves and then use the audio sync frames to adjust the drift.

Here is the  results with the SDL backend and a buffer size of 16384:
https://wiki.blender.org/w/images/2/2d/Old.mp4

And with my changes:
https://wiki.blender.org/w/images/f/fd/AV_sync_mk2.mp4

With my changes, I have a really hard time telling `A/V Sync` and `No Sync` apart :)

This is only a quick and dirty test to add higher resolution audio
position reporting to the SDL backend.

I don't expect this to go in as is at all. It is mostly so we can discuss how to implement this in a good way.

One really bad thing I noticed though:
If I have no audio playing on my system at all, the new reads of audio buffers becomes really sporadic and doesn't match the flow of time at all. I guess this might be a optimization of some sorts. But this is not an issue with this patch per se.