### PR TITLE
Fix corrupted document in python bindings

### DIFF
--- a/bindings/python/PySound.cpp
+++ b/bindings/python/PySound.cpp
@@ -1395,9 +1395,9 @@ PyDoc_STRVAR(M_aud_Sound_threshold_doc,
 			 "   all between to 0.\n\n"
 			 "   :arg threshold: Threshold value over which an amplitude counts\n"
 			 "      non-zero.\n\n"
-			 ":type threshold: float\n"
-			 ":return: The created :class:`Sound` object.\n"
-			 ":rtype: :class:`Sound`");
+			 "   :type threshold: float\n"
+			 "   :return: The created :class:`Sound` object.\n"
+			 "   :rtype: :class:`Sound`");
 
 static PyObject *
 Sound_threshold(Sound* self, PyObject* args)


### PR DESCRIPTION
The document of classmethod aud.Sound.threshold is corrupted due to the incorrect rst format.
This PR fixes it.

c.f. https://developer.blender.org/D8409