### PR TITLE
Fix rendering audio to Matroska container

### DIFF
--- a/plugins/ffmpeg/FFMPEGWriter.cpp
+++ b/plugins/ffmpeg/FFMPEGWriter.cpp
@@ -119,8 +119,8 @@ void FFMPEGWriter::encode()
 
 	while(avcodec_receive_packet(m_codecCtx, m_packet) == 0)
 	{
-		m_packet->stream_index = m_stream->index;
-
+		m_packet->stream_index = m_stream->index;		
+		av_packet_rescale_ts(m_packet, m_codecCtx->time_base, m_stream->time_base);
 		if(av_write_frame(m_formatCtx, m_packet) < 0)
 			AUD_THROW(FileException, "Frame couldn't be writen to the file with ffmpeg.");
 	}
@@ -161,7 +161,7 @@ void FFMPEGWriter::close()
 	while(avcodec_receive_packet(m_codecCtx, m_packet) == 0)
 	{
 		m_packet->stream_index = m_stream->index;
-
+		av_packet_rescale_ts(m_packet, m_codecCtx->time_base, m_stream->time_base);
 		if(av_write_frame(m_formatCtx, m_packet) < 0)
 			AUD_THROW(FileException, "Frame couldn't be writen to the file with ffmpeg.");
 	}

--- a/plugins/ffmpeg/FFMPEGWriter.cpp
+++ b/plugins/ffmpeg/FFMPEGWriter.cpp
@@ -119,7 +119,7 @@ void FFMPEGWriter::encode()
 
 	while(avcodec_receive_packet(m_codecCtx, m_packet) == 0)
 	{
-		m_packet->stream_index = m_stream->index;		
+		m_packet->stream_index = m_stream->index;
 		av_packet_rescale_ts(m_packet, m_codecCtx->time_base, m_stream->time_base);
 		if(av_write_frame(m_formatCtx, m_packet) < 0)
 			AUD_THROW(FileException, "Frame couldn't be writen to the file with ffmpeg.");


### PR DESCRIPTION
Matroska container really really wants to internally keep on using milliseconds as a time base. Even if at initialization time both the `m_stream` and `m_codecCtx` are set to use `{1, sample_rate}` timebase, later during the `avformat_write_header` call the audio stream gets set to `{1, 1000}`.

Doing `av_packet_rescale_ts` for each packet after receiving it but before writing it seems to do all the correct work. This is what is being done inside Blender `movie_write_audio.cc`, and in official ffmpeg `mux.c` example (of course it is not done in ffmpeg `encode_audio.c` example, but that whole example feels like it is from 20+ years ago and does not work with any modern-ish codec or container).