### PR TITLE
Part 1: Add TimeStretchPitchScale effect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ if(AUDASPACE_STANDALONE)
 	option(WITH_LIBSNDFILE "Build With LibSndFile" TRUE)
 	option(WITH_OPENAL "Build With OpenAL" TRUE)
 	option(WITH_PYTHON "Build With Python Library" TRUE)
+	option(WITH_RUBBERBAND "Build With Rubber Band Library" TRUE)
 	option(WITH_SDL "Build With SDL" TRUE)
 	option(WITH_STRICT_DEPENDENCIES "Error and abort instead of warning if a library is not found." FALSE)
 	if(APPLE)
@@ -789,6 +790,39 @@ if(WITH_PYTHON)
 			set(WITH_PYTHON FALSE)
 		endif()
 		message(WARNING "Python & NumPy libraries not found, language binding will not be built.")
+	endif()
+endif()
+
+# Rubber Band Library
+if(WITH_RUBBERBAND)
+	if(AUDASPACE_STANDALONE)
+		find_package(rubberband ${PACKAGE_OPTION})
+	endif()
+
+	if(RUBBERBAND_FOUND)
+		set(RUBBERBAND_SRC
+			src/fx/TimeStretchPitchScale.cpp
+			src/fx/TimeStretchPitchScaleReader.cpp
+		)
+		set(RUBBERBAND_HDR
+			include/fx/TimeStretchPitchScale.h
+			include/fx/TimeStretchPitchScaleReader.h
+		)
+
+		add_definitions(-DWITH_RUBBERBAND)
+
+		list(APPEND INCLUDE ${RUBBERBAND_INCLUDE_DIRS})
+		list(APPEND LIBRARIES ${RUBBERBAND_LIBRARIES})
+
+		list(APPEND SRC ${RUBBERBAND_SRC})
+		list(APPEND HDR ${RUBBERBAND_HDR})
+	else()
+		if(AUDASPACE_STANDALONE)
+			set(WITH_RUBBERBAND FALSE CACHE BOOL "Build with Rubber Band" FORCE)
+		else()
+			set(WITH_RUBBERBAND FALSE)
+		endif()
+		message(WARNING "Rubber Band Library not found, time-stretching and pitch-scaling functionality will not be built.")
 	endif()
 endif()
 

--- a/bindings/C/AUD_Sound.cpp
+++ b/bindings/C/AUD_Sound.cpp
@@ -795,12 +795,12 @@ AUD_API AUD_Sound* AUD_Sound_equalize(AUD_Sound* sound, float *definition, int s
 #endif
 
 #ifdef WITH_RUBBERBAND
-AUD_API AUD_Sound* AUD_Sound_timeStretchPitchScale(AUD_Sound* sound, double timeRatio, double pitchScale, AUD_StretcherQualityOptions quality, bool preserveFormant)
+AUD_API AUD_Sound* AUD_Sound_timeStretchPitchScale(AUD_Sound* sound, double timeRatio, double pitchScale, AUD_StretcherQualityOption quality, bool preserveFormant)
 {
 	assert(sound);
 	try
 	{
-		return new AUD_Sound(new TimeStretchPitchScale(*sound, timeRatio, pitchScale, quality, preserveFormant));
+		return new AUD_Sound(new TimeStretchPitchScale(*sound, timeRatio, pitchScale, static_cast<StretcherQualityOption>(quality), preserveFormant));
 	}
 	catch(Exception&)
 	{

--- a/bindings/C/AUD_Sound.cpp
+++ b/bindings/C/AUD_Sound.cpp
@@ -57,6 +57,10 @@
 #include "fx/Equalizer.h"
 #endif
 
+#ifdef WITH_RUBBERBAND
+#include "fx/TimeStretchPitchScale.h"
+#endif
+
 #include <cassert>
 #include <cstring>
 
@@ -788,4 +792,19 @@ AUD_API AUD_Sound* AUD_Sound_equalize(AUD_Sound* sound, float *definition, int s
 	return equalizer;
 }
 
+#endif
+
+#ifdef WITH_RUBBERBAND
+AUD_API AUD_Sound* AUD_Sound_timeStretchPitchScale(AUD_Sound* sound, double timeRatio, double pitchScale, AUD_StretcherQualityOptions quality, bool preserveFormant)
+{
+	assert(sound);
+	try
+	{
+		return new AUD_Sound(new TimeStretchPitchScale(*sound, timeRatio, pitchScale, quality, preserveFormant));
+	}
+	catch(Exception&)
+	{
+		return nullptr;
+	}
+}
 #endif

--- a/bindings/C/AUD_Sound.h
+++ b/bindings/C/AUD_Sound.h
@@ -423,5 +423,5 @@ extern AUD_API AUD_Sound* AUD_Sound_mutable(AUD_Sound* sound);
 #endif
 
 #ifdef __cplusplus
-    }
+}
 #endif

--- a/bindings/C/AUD_Sound.h
+++ b/bindings/C/AUD_Sound.h
@@ -419,7 +419,7 @@ extern AUD_API AUD_Sound* AUD_Sound_mutable(AUD_Sound* sound);
      * \param preserveFormant Whether to preserve the vocal formants for the stretcher.
      * \return A handle of the time-stretched, pitch scaled sound.
      */
-    extern AUD_API AUD_Sound* AUD_Sound_timeStretchPitchScale(AUD_Sound* sound, double timeRatio, double pitchScale, AUD_StretcherQualityOptions quality, bool preserveFormant);
+    extern AUD_API AUD_Sound* AUD_Sound_timeStretchPitchScale(AUD_Sound* sound, double timeRatio, double pitchScale, AUD_StretcherQualityOption quality, bool preserveFormant);
 #endif
 
 #ifdef __cplusplus

--- a/bindings/C/AUD_Sound.h
+++ b/bindings/C/AUD_Sound.h
@@ -409,6 +409,19 @@ extern AUD_API AUD_Sound* AUD_Sound_mutable(AUD_Sound* sound);
 	extern AUD_API AUD_Sound* AUD_Sound_equalize(AUD_Sound* sound, float *definition, int size, float maxFreqEq, int sizeConversion);
 #endif
 
+#ifdef WITH_RUBBERBAND
+    /**
+     * Time-stretches and pitch scales a sound.
+     * \param sound The handle of the sound.
+     * \param timeRatio The factor by which to stretch or compress time.
+     * \param pitchScale The factor by which to adjust the pitch.
+     * \param quality The processing quality level of the stretcher.
+     * \param preserveFormant Whether to preserve the vocal formants for the stretcher.
+     * \return A handle of the time-stretched, pitch scaled sound.
+     */
+    extern AUD_API AUD_Sound* AUD_Sound_timeStretchPitchScale(AUD_Sound* sound, double timeRatio, double pitchScale, AUD_StretcherQualityOptions quality, bool preserveFormant);
+#endif
+
 #ifdef __cplusplus
-}
+    }
 #endif

--- a/bindings/C/AUD_Types.h
+++ b/bindings/C/AUD_Types.h
@@ -208,5 +208,5 @@ typedef enum
 {
 	AUD_STRETCHER_QUALITY_HIGH = 0,      /// Prioritize high-quality pitch processing
 	AUD_STRETCHER_QUALITY_FAST = 1,      /// Prioritize speed over audio quality
-	AUD_STRETCHER_QUALITY_CONSISTENT = 2 ///  Prioritize consistency for dynamic pitch changes
+	AUD_STRETCHER_QUALITY_CONSISTENT = 2 /// Prioritize consistency for dynamic pitch changes
 } AUD_StretcherQualityOption;

--- a/bindings/C/AUD_Types.h
+++ b/bindings/C/AUD_Types.h
@@ -206,15 +206,7 @@ typedef struct
  */
 typedef enum
 {
-	AUD_STRETCHER_QUALITY_FASTEST = 1 << 0,
-	AUD_STRETCHER_QUALITY_HIGH = 1 << 1,
-	AUD_STRETCHER_QUALITY_CRISP_0 = 1 << 2,
-	AUD_STRETCHER_QUALITY_CRISP_1 = 1 << 3,
-	AUD_STRETCHER_QUALITY_CRISP_2 = 1 << 4,
-	AUD_STRETCHER_QUALITY_CRISP_3 = 1 << 5,
-	AUD_STRETCHER_QUALITY_CRISP_4 = 1 << 6,
-	AUD_STRETCHER_QUALITY_CRISP_5 = 1 << 7,
-	AUD_STRETCHER_QUALITY_CRISP_6 = 1 << 8,
+	AUD_STRETCHER_QUALITY_HIGH = 0,      /// Prioritize high-quality pitch processing
+	AUD_STRETCHER_QUALITY_FAST = 1,      /// Prioritize speed over audio quality
+	AUD_STRETCHER_QUALITY_CONSISTENT = 2 ///  Prioritize consistency for dynamic pitch changes
 } AUD_StretcherQualityOption;
-
-typedef int AUD_StretcherQualityOptions;

--- a/bindings/C/AUD_Types.h
+++ b/bindings/C/AUD_Types.h
@@ -200,3 +200,21 @@ typedef struct
 	/// Audio data parameters.
 	AUD_DeviceSpecs specs;
 } AUD_StreamInfo;
+
+/**
+ * The Rubber Band stretcher quality options
+ */
+typedef enum
+{
+	AUD_STRETCHER_QUALITY_FASTEST = 1 << 0,
+	AUD_STRETCHER_QUALITY_HIGH = 1 << 1,
+	AUD_STRETCHER_QUALITY_CRISP_0 = 1 << 2,
+	AUD_STRETCHER_QUALITY_CRISP_1 = 1 << 3,
+	AUD_STRETCHER_QUALITY_CRISP_2 = 1 << 4,
+	AUD_STRETCHER_QUALITY_CRISP_3 = 1 << 5,
+	AUD_STRETCHER_QUALITY_CRISP_4 = 1 << 6,
+	AUD_STRETCHER_QUALITY_CRISP_5 = 1 << 7,
+	AUD_STRETCHER_QUALITY_CRISP_6 = 1 << 8,
+} AUD_StretcherQualityOption;
+
+typedef int AUD_StretcherQualityOptions;

--- a/bindings/python/PyAPI.cpp
+++ b/bindings/python/PyAPI.cpp
@@ -31,24 +31,22 @@
 #endif
 
 #ifdef WITH_RUBBERBAND
-
+#include "fx/TimeStretchPitchScale.h"
 #endif
+
+#include "respec/Specification.h"
+#include "devices/IHandle.h"
+#include "devices/I3DDevice.h"
+#include "file/IWriter.h"
+#include "plugin/PluginManager.h"
+#include "sequence/AnimateableProperty.h"
+#include "ISound.h"
+
 #include <memory>
 
 #include <structmember.h>
 
-#include "ISound.h"
-
-#include "devices/I3DDevice.h"
-#include "devices/IHandle.h"
-#include "file/IWriter.h"
-#include "fx/TimeStretchPitchScale.h"
-#include "plugin/PluginManager.h"
-#include "respec/Specification.h"
-#include "sequence/AnimateableProperty.h"
-
 using namespace aud;
-
 // ====================================================================
 
 #define PY_MODULE_ADD_CONSTANT(module, name) PyModule_AddIntConstant(module, #name, name)

--- a/bindings/python/PyAPI.cpp
+++ b/bindings/python/PyAPI.cpp
@@ -30,17 +30,22 @@
 #include "PyHRTF.h"
 #endif
 
-#include "respec/Specification.h"
-#include "devices/IHandle.h"
-#include "devices/I3DDevice.h"
-#include "file/IWriter.h"
-#include "plugin/PluginManager.h"
-#include "sequence/AnimateableProperty.h"
-#include "ISound.h"
+#ifdef WITH_RUBBERBAND
 
+#endif
 #include <memory>
 
 #include <structmember.h>
+
+#include "ISound.h"
+
+#include "devices/I3DDevice.h"
+#include "devices/IHandle.h"
+#include "file/IWriter.h"
+#include "fx/TimeStretchPitchScale.h"
+#include "plugin/PluginManager.h"
+#include "respec/Specification.h"
+#include "sequence/AnimateableProperty.h"
 
 using namespace aud;
 
@@ -202,6 +207,13 @@ PyInit_aud()
 	PY_MODULE_ADD_CONSTANT(module, STATUS_PAUSED);
 	PY_MODULE_ADD_CONSTANT(module, STATUS_PLAYING);
 	PY_MODULE_ADD_CONSTANT(module, STATUS_STOPPED);
+
+#ifdef WITH_RUBBERBAND
+	// stretcher quality options
+	PyModule_AddIntConstant(module, "STRETCHER_QUALITY_HIGH", static_cast<int>(StretcherQualityOption::HIGH));
+	PyModule_AddIntConstant(module, "STRETCHER_QUALITY_FAST", static_cast<int>(StretcherQualityOption::FAST));
+	PyModule_AddIntConstant(module, "STRETCHER_QUALITY_CONSISTENT", static_cast<int>(StretcherQualityOption::CONSISTENT));
+#endif
 
 	return module;
 }

--- a/bindings/python/PySound.cpp
+++ b/bindings/python/PySound.cpp
@@ -64,6 +64,11 @@
 #include "fx/ConvolverSound.h"
 #endif
 
+
+#ifdef WITH_RUBBERBAND
+#include "fx/TimeStretchPitchScale.h"
+#endif
+
 #include <cstring>
 #include <structmember.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
@@ -444,7 +449,7 @@ PyDoc_STRVAR(M_aud_Sound_sawtooth_doc,
 			 "   :arg frequency: The frequency of the sawtooth wave in Hz.\n"
 			 "   :type frequency: float\n"
 			 "   :arg rate: The sampling rate in Hz. It's recommended to set this\n"
-			 "      value to the playback device's samling rate to avoid resamping.\n"
+			 "      value to the playback device's sampling rate to avoid resampling.\n"
 			 "   :type rate: int\n"
 			 "   :return: The created :class:`Sound` object.\n"
 			 "   :rtype: :class:`Sound`");
@@ -482,7 +487,7 @@ PyDoc_STRVAR(M_aud_Sound_silence_doc,
 			 ".. classmethod:: silence(rate=48000)\n\n"
 			 "   Creates a silence sound which plays simple silence.\n\n"
 			 "   :arg rate: The sampling rate in Hz. It's recommended to set this\n"
-			 "      value to the playback device's samling rate to avoid resamping.\n"
+			 "      value to the playback device's sampling rate to avoid resampling.\n"
 			 "   :type rate: int\n"
 			 "   :return: The created :class:`Sound` object.\n"
 			 "   :rtype: :class:`Sound`");
@@ -521,7 +526,7 @@ PyDoc_STRVAR(M_aud_Sound_sine_doc,
 			 "   :arg frequency: The frequency of the sine wave in Hz.\n"
 			 "   :type frequency: float\n"
 			 "   :arg rate: The sampling rate in Hz. It's recommended to set this\n"
-			 "      value to the playback device's samling rate to avoid resamping.\n"
+			 "      value to the playback device's sampling rate to avoid resampling.\n"
 			 "   :type rate: int\n"
 			 "   :return: The created :class:`Sound` object.\n"
 			 "   :rtype: :class:`Sound`");
@@ -561,7 +566,7 @@ PyDoc_STRVAR(M_aud_Sound_square_doc,
 			 "   :arg frequency: The frequency of the square wave in Hz.\n"
 			 "   :type frequency: float\n"
 			 "   :arg rate: The sampling rate in Hz. It's recommended to set this\n"
-			 "      value to the playback device's samling rate to avoid resamping.\n"
+			 "      value to the playback device's sampling rate to avoid resampling.\n"
 			 "   :type rate: int\n"
 			 "   :return: The created :class:`Sound` object.\n"
 			 "   :rtype: :class:`Sound`");
@@ -601,7 +606,7 @@ PyDoc_STRVAR(M_aud_Sound_triangle_doc,
 			 "   :arg frequency: The frequency of the triangle wave in Hz.\n"
 			 "   :type frequency: float\n"
 			 "   :arg rate: The sampling rate in Hz. It's recommended to set this\n"
-			 "      value to the playback device's samling rate to avoid resamping.\n"
+			 "      value to the playback device's sampling rate to avoid resampling.\n"
 			 "   :type rate: int\n"
 			 "   :return: The created :class:`Sound` object.\n"
 			 "   :rtype: :class:`Sound`");
@@ -1787,6 +1792,58 @@ Sound_binaural(Sound* self, PyObject* args)
 
 #endif
 
+#ifdef WITH_RUBBERBAND
+
+PyDoc_STRVAR(M_aud_Sound_timeStretchPitchScale_doc,
+	".. method:: timeStretchPitchScale(time_ratio, pitch_scale, quality, preserve_formant)\n\n"
+	"   Applies time-stretching and pitch-scaling to the sound.\n\n"
+	"   :arg time_ratio: The factor by which to stretch or compress time.\n"
+	"   :type time_ratio: float\n"
+	"   :arg pitch_scale: The factor by which to adjust the pitch.\n"
+	"   :type pitch_scale: float\n"
+	"   :arg quality: Rubberband stretcher quality option (0 = HIGH, 1 = FAST, 2 = CONSISTENT).\n"
+	"   :type quality: int\n"
+	"   :arg preserve_formant: Whether to preserve the vocal formants during pitch-shifting.\n"
+	"   :type preserve_formant: bool\n"
+	"   :return: The created :class:`Sound` object.\n"
+	"   :rtype: :class:`Sound`");
+static PyObject * 
+Sound_timeStretchPitchScale(Sound* self, PyObject* args)
+{
+	double time_ratio, pitch_scale;
+	int quality = 0;
+	int preserve_formant = 0;
+	if(!PyArg_ParseTuple(args, "dd|i|p:timeStretchPitchScale", &time_ratio, &pitch_scale, &quality, &preserve_formant))
+		return nullptr;
+
+	if(quality < 0 || quality > 2)
+	{
+		PyErr_WarnEx(PyExc_UserWarning, "Invalid quality value: using default (0 = HIGH)", 1);
+		quality = 0;
+	}
+
+	PyTypeObject* type = Py_TYPE(self);
+	Sound* parent = (Sound*) type->tp_alloc(type, 0);
+
+	if(parent != nullptr)
+	{
+		try
+		{
+			parent->sound = new std::shared_ptr<ISound>(new TimeStretchPitchScale(*reinterpret_cast<std::shared_ptr<ISound>*>(self->sound), time_ratio, pitch_scale,
+			                                                                      static_cast<StretcherQualityOption>(quality), preserve_formant != 0));
+		}
+		catch(Exception& e)
+		{
+			Py_DECREF(parent);
+			PyErr_SetString(AUDError, e.what());
+			return nullptr;
+		}
+	}
+
+	return (PyObject*)parent;
+}
+
+#endif
 static PyMethodDef Sound_methods[] = {
 	{"data", (PyCFunction)Sound_data, METH_NOARGS,
 	 M_aud_Sound_data_doc
@@ -1899,6 +1956,11 @@ static PyMethodDef Sound_methods[] = {
 	},
 	{ "binaural", (PyCFunction)Sound_binaural, METH_VARARGS,
 	M_aud_Sound_binaural_doc
+	},
+#endif
+#ifdef WITH_RUBBERBAND
+	{"timeStretchPitchScale", (PyCFunction)Sound_timeStretchPitchScale, METH_VARARGS,
+	 M_aud_Sound_timeStretchPitchScale_doc
 	},
 #endif
 	{nullptr}  /* Sentinel */

--- a/include/fx/TimeStretchPitchScale.h
+++ b/include/fx/TimeStretchPitchScale.h
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright 2009-2025 Jörg Müller
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#pragma once
+
+/**
+ * @file TimeStretchPitchScale.h
+ * @ingroup fx
+ * The TimeStretchPitchScale class.
+ */
+
+#include "fx/Effect.h"
+
+AUD_NAMESPACE_BEGIN
+
+enum StretcherQualityOption
+{
+	FASTEST = 1 << 0, // Use the high speed pitch speed
+	HIGH = 1 << 1,    // Use high quality pitch option
+
+	// Crispness options correspond to https://breakfastquay.com/rubberband/usage.txt and https://hg.sr.ht/~breakfastquay/rubberband-qt-example/browse/src/Processor.cpp?rev=tip
+	// NOTE: These really only apply when the R2 engine is used, that is when OptionEngineFaster is used, though window size does affect the R3 engine.
+	CRISP_0 = 1 << 2,
+	CRISP_1 = 1 << 3,
+	CRISP_2 = 1 << 4,
+	CRISP_3 = 1 << 5,
+	CRISP_4 = 1 << 6,
+	CRISP_5 = 1 << 7,
+	CRISP_6 = 1 << 8,
+};
+
+typedef int StretcherQualityOptions;
+
+/**
+ * This sound allows a sound to be time-stretched and pitch scaled.
+ * \note The reader has to be seekable.
+ */
+class AUD_API TimeStretchPitchScale : public Effect
+{
+private:
+	/**
+	 * The pitch scale to change the sound by.
+	 */
+	double m_pitchScale;
+
+	/**
+	 * The time ratio to stretch the sound by.
+	 */
+	double m_timeRatio;
+
+	/**
+	 * The quality of the pitch correction when time-stretching.
+	 */
+	StretcherQualityOptions m_quality;
+
+	// delete copy constructor and operator=
+	TimeStretchPitchScale(const TimeStretchPitchScale&) = delete;
+	TimeStretchPitchScale& operator=(const TimeStretchPitchScale&) = delete;
+
+public:
+	/**
+	 * Creates a new time-stretch, pitch scaled sound.
+	 * \param sound The input sound.
+	 * \param timeRatio The time ratio to stretch by for the stretcher.
+	 * \param ratio The pitch scale to change by fort he stretcher.
+	 */
+	TimeStretchPitchScale(std::shared_ptr<ISound> sound, double timeRatio, double pitchScale, StretcherQualityOptions quality);
+
+	/**
+	 * Returns the time ratio.
+	 */
+	double getTimeRatio() const;
+
+	/**
+	 * Returns the pitch scale.
+	 */
+	double getPitchScale() const;
+	virtual std::shared_ptr<IReader> createReader();
+};
+
+AUD_NAMESPACE_END

--- a/include/fx/TimeStretchPitchScale.h
+++ b/include/fx/TimeStretchPitchScale.h
@@ -81,7 +81,7 @@ public:
 	 * \param sound The input sound.
 	 * \param timeRatio The factor by which to stretch or compress time.
 	 * \param pitchScale The factor by which to adjust the pitch.
-	 * \param quality The quality of the stretcher.
+	 * \param quality The processing quality level.
 	 * \param preserveFormant Whether to preserve the vocal formants for the stretcher.
 	 */
 	TimeStretchPitchScale(std::shared_ptr<ISound> sound, double timeRatio, double pitchScale, StretcherQualityOptions quality, bool preserveFormant);

--- a/include/fx/TimeStretchPitchScale.h
+++ b/include/fx/TimeStretchPitchScale.h
@@ -52,19 +52,24 @@ class AUD_API TimeStretchPitchScale : public Effect
 {
 private:
 	/**
-	 * The pitch scale to change the sound by.
+	 * The factor by which to adjust the pitch.
 	 */
 	double m_pitchScale;
 
 	/**
-	 * The time ratio to stretch the sound by.
+	 * The factor by which to stretch or compress time.
 	 */
 	double m_timeRatio;
 
 	/**
-	 * The quality of the pitch correction when time-stretching.
+	 * Rubberband stretcher quality options.
 	 */
 	StretcherQualityOptions m_quality;
+
+	/**
+	 * Whether to preserve the vocal formants for the stretcher
+	 */
+	bool m_preserveFormant;
 
 	// delete copy constructor and operator=
 	TimeStretchPitchScale(const TimeStretchPitchScale&) = delete;
@@ -74,10 +79,12 @@ public:
 	/**
 	 * Creates a new time-stretch, pitch scaled sound.
 	 * \param sound The input sound.
-	 * \param timeRatio The time ratio to stretch by for the stretcher.
-	 * \param ratio The pitch scale to change by fort he stretcher.
+	 * \param timeRatio The factor by which to stretch or compress time.
+	 * \param pitchScale The factor by which to adjust the pitch.
+	 * \param quality The quality
+	 * \param preserveFormant
 	 */
-	TimeStretchPitchScale(std::shared_ptr<ISound> sound, double timeRatio, double pitchScale, StretcherQualityOptions quality);
+	TimeStretchPitchScale(std::shared_ptr<ISound> sound, double timeRatio, double pitchScale, StretcherQualityOptions quality, bool preserveFormant);
 
 	/**
 	 * Returns the time ratio.
@@ -88,6 +95,11 @@ public:
 	 * Returns the pitch scale.
 	 */
 	double getPitchScale() const;
+
+	/**
+	 * Returns whether formant preservation is enabled.
+	 */
+	bool getPreserveFormant() const;
 	virtual std::shared_ptr<IReader> createReader();
 };
 

--- a/include/fx/TimeStretchPitchScale.h
+++ b/include/fx/TimeStretchPitchScale.h
@@ -81,8 +81,8 @@ public:
 	 * \param sound The input sound.
 	 * \param timeRatio The factor by which to stretch or compress time.
 	 * \param pitchScale The factor by which to adjust the pitch.
-	 * \param quality The quality
-	 * \param preserveFormant
+	 * \param quality The quality of the stretcher.
+	 * \param preserveFormant Whether to preserve the vocal formants for the stretcher.
 	 */
 	TimeStretchPitchScale(std::shared_ptr<ISound> sound, double timeRatio, double pitchScale, StretcherQualityOptions quality, bool preserveFormant);
 

--- a/include/fx/TimeStretchPitchScale.h
+++ b/include/fx/TimeStretchPitchScale.h
@@ -41,14 +41,14 @@ class AUD_API TimeStretchPitchScale : public Effect
 {
 private:
 	/**
-	 * The factor by which to adjust the pitch.
-	 */
-	double m_pitchScale;
-
-	/**
 	 * The factor by which to stretch or compress time.
 	 */
 	double m_timeRatio;
+
+	/**
+	 * The factor by which to adjust the pitch.
+	 */
+	double m_pitchScale;
 
 	/**
 	 * Rubberband stretcher quality options.
@@ -56,7 +56,7 @@ private:
 	StretcherQualityOption m_quality;
 
 	/**
-	 * Whether to preserve the vocal formants for the stretcher
+	 * Whether to preserve the vocal formants during pitch-shifting
 	 */
 	bool m_preserveFormant;
 

--- a/include/fx/TimeStretchPitchScale.h
+++ b/include/fx/TimeStretchPitchScale.h
@@ -26,23 +26,12 @@
 
 AUD_NAMESPACE_BEGIN
 
-enum StretcherQualityOption
+enum class StretcherQualityOption
 {
-	FASTEST = 1 << 0, // Use the high speed pitch speed
-	HIGH = 1 << 1,    // Use high quality pitch option
-
-	// Crispness options correspond to https://breakfastquay.com/rubberband/usage.txt and https://hg.sr.ht/~breakfastquay/rubberband-qt-example/browse/src/Processor.cpp?rev=tip
-	// NOTE: These really only apply when the R2 engine is used, that is when OptionEngineFaster is used, though window size does affect the R3 engine.
-	CRISP_0 = 1 << 2,
-	CRISP_1 = 1 << 3,
-	CRISP_2 = 1 << 4,
-	CRISP_3 = 1 << 5,
-	CRISP_4 = 1 << 6,
-	CRISP_5 = 1 << 7,
-	CRISP_6 = 1 << 8,
+	HIGH = 0,      // Prioritize high-quality pitch processing
+	FAST = 1,      // Prioritize speed over audio quality
+	CONSISTENT = 2 // Prioritize consistency for dynamic pitch changes
 };
-
-typedef int StretcherQualityOptions;
 
 /**
  * This sound allows a sound to be time-stretched and pitch scaled.
@@ -64,7 +53,7 @@ private:
 	/**
 	 * Rubberband stretcher quality options.
 	 */
-	StretcherQualityOptions m_quality;
+	StretcherQualityOption m_quality;
 
 	/**
 	 * Whether to preserve the vocal formants for the stretcher
@@ -84,7 +73,7 @@ public:
 	 * \param quality The processing quality level.
 	 * \param preserveFormant Whether to preserve the vocal formants for the stretcher.
 	 */
-	TimeStretchPitchScale(std::shared_ptr<ISound> sound, double timeRatio, double pitchScale, StretcherQualityOptions quality, bool preserveFormant);
+	TimeStretchPitchScale(std::shared_ptr<ISound> sound, double timeRatio, double pitchScale, StretcherQualityOption quality, bool preserveFormant);
 
 	/**
 	 * Returns the time ratio.

--- a/include/fx/TimeStretchPitchScaleReader.h
+++ b/include/fx/TimeStretchPitchScaleReader.h
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright 2009-2025 Jörg Müller
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#pragma once
+
+/**
+ * @file TimeStretchPitchScaleReader.h
+ * @ingroup fx
+ * The TimeStretchPitchScale class.
+ */
+
+#include "TimeStretchPitchScale.h"
+
+#include "fx/EffectReader.h"
+#include "rubberband/RubberBandStretcher.h"
+#include "util/Buffer.h"
+
+using namespace RubberBand;
+
+AUD_NAMESPACE_BEGIN
+
+/**
+ * This class reads from another reader and applies time stretching and pitch scaling.
+ */
+class AUD_API TimeStretchPitchScaleReader : public EffectReader
+{
+private:
+	/**
+	 * The current position.
+	 */
+	int m_position;
+
+	/**
+	 * Whether the reader has reached the end of stream
+	 */
+	bool m_finishedReader;
+
+	/**
+	 * The input buffer for the reader
+	 */
+	Buffer m_buffer;
+
+	/**
+	 * The input deinterleaved buffers for each channel
+	 */
+	std::vector<Buffer> m_input;
+
+	/**
+	 * The pointers to the input deinterleaved buffer data for processing
+	 */
+	std::vector<sample_t*> m_processData;
+
+	/**
+	 * The output deinterleaved buffers for each channel
+	 */
+	std::vector<Buffer> m_output;
+
+	/**
+	 * The pointers to the output deinterleaved buffer data
+	 */
+	std::vector<sample_t*> m_retrieveData;
+
+	/**
+	 * The length of the output.
+	 */
+	int m_length;
+
+	/**
+	 * The time ratio for the stretcher.
+	 */
+	double m_timeRatio;
+
+	/**
+	 * The pitch scale for the stretcher.
+	 */
+	double m_pitchScale;
+
+	/**
+	 * Rubberband stretcher.
+	 */
+	RubberBandStretcher* m_stretcher;
+
+	/**
+	 * Rubberband stretcher quality options.
+	 */
+	StretcherQualityOptions m_quality;
+
+	// delete copy constructor and operator=
+	TimeStretchPitchScaleReader(const TimeStretchPitchScaleReader&) = delete;
+	TimeStretchPitchScaleReader& operator=(const TimeStretchPitchScaleReader&) = delete;
+
+public:
+	/**
+	 * Creates a new stretcher reader.
+	 * \param reader The reader to read from.
+	 * \param time_ratio The time ratio for the stretcher.
+	 */
+	TimeStretchPitchScaleReader(std::shared_ptr<IReader> reader, double time_ratio, double pitch_scale, StretcherQualityOptions quality);
+
+	~TimeStretchPitchScaleReader();
+
+	virtual void read(int& length, bool& eos, sample_t* buffer);
+
+	virtual void seek(int position);
+	virtual int getLength() const;
+	virtual int getPosition() const;
+
+	/**
+	 * Retrieves the current time ratio for the stretcher.
+	 * \return The current time ratio value.
+	 */
+	double getTimeRatio() const;
+
+	/**
+	 * Sets the time ratio for the stretcher.
+	 */
+	void setTimeRatio(double timeRatio);
+
+	/**
+	 * Retrieves the pitch scale for the stretcher
+	 * \return The current pitch scale value.
+	 */
+	double getPitchScale() const;
+
+	/**
+	 * Sets the pitch scale for the stretcher.
+	 */
+	void setPitchScale(double pitchScale);
+
+	/**
+	 * Sets the configuration for the stretcher
+	 */
+	void configure(StretcherQualityOptions quality);
+};
+
+AUD_NAMESPACE_END

--- a/include/fx/TimeStretchPitchScaleReader.h
+++ b/include/fx/TimeStretchPitchScaleReader.h
@@ -54,54 +54,19 @@ private:
 	Buffer m_buffer;
 
 	/**
-	 * The input deinterleaved buffers for each channel.
+	 * The input/output deinterleaved buffers for each channel.
 	 */
-	std::vector<Buffer> m_input;
+	std::vector<Buffer> m_deinterleaved;
 
 	/**
-	 * The pointers to the input deinterleaved buffer data for processing.
+	 * The pointers to the input/output deinterleaved buffer data for processing/retrieving.
 	 */
-	std::vector<sample_t*> m_processData;
-
-	/**
-	 * The output deinterleaved buffers for each channel.
-	 */
-	std::vector<Buffer> m_output;
-
-	/**
-	 * The pointers to the output deinterleaved buffer data.
-	 */
-	std::vector<sample_t*> m_retrieveData;
-
-	/**
-	 * The length of the output.
-	 */
-	int m_length;
-
-	/**
-	 * The time ratio for the stretcher.
-	 */
-	double m_timeRatio;
-
-	/**
-	 * The pitch scale for the stretcher.
-	 */
-	double m_pitchScale;
+	std::vector<sample_t*> m_channelData;
 
 	/**
 	 * Rubberband stretcher.
 	 */
 	std::unique_ptr<RubberBandStretcher> m_stretcher;
-
-	/**
-	 * Whether to preserve the vocal formants for the stretcher.
-	 */
-	bool m_preserveFormant;
-
-	/**
-	 * Rubberband stretcher quality options.
-	 */
-	StretcherQualityOption m_quality;
 
 	// delete copy constructor and operator=
 	TimeStretchPitchScaleReader(const TimeStretchPitchScaleReader&) = delete;
@@ -142,20 +107,9 @@ public:
 	double getPitchScale() const;
 
 	/**
-	 * Retrieves the formant preservation setting.
-	 * \return True if formant preservation is enabled. Otherwise, false.
-	 */
-	bool getPreserveFormant() const;
-
-	/**
 	 * Sets the pitch scale for the stretcher.
 	 */
 	void setPitchScale(double pitchScale);
-
-	/**
-	 * Sets the configuration for the stretcher.
-	 */
-	void configure(StretcherQualityOption quality, bool preserveFormant);
 };
 
 AUD_NAMESPACE_END

--- a/include/fx/TimeStretchPitchScaleReader.h
+++ b/include/fx/TimeStretchPitchScaleReader.h
@@ -94,6 +94,11 @@ private:
 	RubberBandStretcher* m_stretcher;
 
 	/**
+	 * Whether to preserve the vocal formants for the stretcher
+	 */
+	bool m_preserveFormant;
+
+	/**
 	 * Rubberband stretcher quality options.
 	 */
 	StretcherQualityOptions m_quality;
@@ -108,7 +113,7 @@ public:
 	 * \param reader The reader to read from.
 	 * \param time_ratio The time ratio for the stretcher.
 	 */
-	TimeStretchPitchScaleReader(std::shared_ptr<IReader> reader, double time_ratio, double pitch_scale, StretcherQualityOptions quality);
+	TimeStretchPitchScaleReader(std::shared_ptr<IReader> reader, double time_ratio, double pitch_scale, StretcherQualityOptions quality, bool preserveFormant);
 
 	~TimeStretchPitchScaleReader();
 
@@ -143,7 +148,7 @@ public:
 	/**
 	 * Sets the configuration for the stretcher
 	 */
-	void configure(StretcherQualityOptions quality);
+	void configure(StretcherQualityOptions quality, bool preserveFormant);
 };
 
 AUD_NAMESPACE_END

--- a/include/fx/TimeStretchPitchScaleReader.h
+++ b/include/fx/TimeStretchPitchScaleReader.h
@@ -113,7 +113,7 @@ public:
 	 * \param reader The reader to read from.
 	 * \param timeRatio The factor by which to stretch or compress time.
 	 * \param pitchScale The factor by which to adjust the pitch.
-	 * \param quality The quality of the stretcher.
+	 * \param quality The processing quality level of the stretcher.
 	 * \param preserveFormant Whether to preserve the vocal formants for the stretcher.
 	 */
 	TimeStretchPitchScaleReader(std::shared_ptr<IReader> reader, double timeRatio, double pitchScale, StretcherQualityOptions quality, bool preserveFormant);

--- a/include/fx/TimeStretchPitchScaleReader.h
+++ b/include/fx/TimeStretchPitchScaleReader.h
@@ -101,7 +101,7 @@ private:
 	/**
 	 * Rubberband stretcher quality options.
 	 */
-	StretcherQualityOptions m_quality;
+	StretcherQualityOption m_quality;
 
 	// delete copy constructor and operator=
 	TimeStretchPitchScaleReader(const TimeStretchPitchScaleReader&) = delete;
@@ -116,7 +116,7 @@ public:
 	 * \param quality The processing quality level of the stretcher.
 	 * \param preserveFormant Whether to preserve the vocal formants for the stretcher.
 	 */
-	TimeStretchPitchScaleReader(std::shared_ptr<IReader> reader, double timeRatio, double pitchScale, StretcherQualityOptions quality, bool preserveFormant);
+	TimeStretchPitchScaleReader(std::shared_ptr<IReader> reader, double timeRatio, double pitchScale, StretcherQualityOption quality, bool preserveFormant);
 
 	virtual void read(int& length, bool& eos, sample_t* buffer);
 
@@ -155,7 +155,7 @@ public:
 	/**
 	 * Sets the configuration for the stretcher.
 	 */
-	void configure(StretcherQualityOptions quality, bool preserveFormant);
+	void configure(StretcherQualityOption quality, bool preserveFormant);
 };
 
 AUD_NAMESPACE_END

--- a/include/fx/TimeStretchPitchScaleReader.h
+++ b/include/fx/TimeStretchPitchScaleReader.h
@@ -44,32 +44,32 @@ private:
 	int m_position;
 
 	/**
-	 * Whether the reader has reached the end of stream
+	 * Whether the reader has reached the end of stream.
 	 */
 	bool m_finishedReader;
 
 	/**
-	 * The input buffer for the reader
+	 * The input buffer for the reader.
 	 */
 	Buffer m_buffer;
 
 	/**
-	 * The input deinterleaved buffers for each channel
+	 * The input deinterleaved buffers for each channel.
 	 */
 	std::vector<Buffer> m_input;
 
 	/**
-	 * The pointers to the input deinterleaved buffer data for processing
+	 * The pointers to the input deinterleaved buffer data for processing.
 	 */
 	std::vector<sample_t*> m_processData;
 
 	/**
-	 * The output deinterleaved buffers for each channel
+	 * The output deinterleaved buffers for each channel.
 	 */
 	std::vector<Buffer> m_output;
 
 	/**
-	 * The pointers to the output deinterleaved buffer data
+	 * The pointers to the output deinterleaved buffer data.
 	 */
 	std::vector<sample_t*> m_retrieveData;
 
@@ -111,9 +111,12 @@ public:
 	/**
 	 * Creates a new stretcher reader.
 	 * \param reader The reader to read from.
-	 * \param time_ratio The time ratio for the stretcher.
+	 * \param timeRatio The factor by which to stretch or compress time.
+	 * \param pitchScale The factor by which to adjust the pitch.
+	 * \param quality The quality of the stretcher.
+	 * \param preserveFormant Whether to preserve the vocal formants for the stretcher.
 	 */
-	TimeStretchPitchScaleReader(std::shared_ptr<IReader> reader, double time_ratio, double pitch_scale, StretcherQualityOptions quality, bool preserveFormant);
+	TimeStretchPitchScaleReader(std::shared_ptr<IReader> reader, double timeRatio, double pitchScale, StretcherQualityOptions quality, bool preserveFormant);
 
 	~TimeStretchPitchScaleReader();
 

--- a/include/fx/TimeStretchPitchScaleReader.h
+++ b/include/fx/TimeStretchPitchScaleReader.h
@@ -19,7 +19,7 @@
 /**
  * @file TimeStretchPitchScaleReader.h
  * @ingroup fx
- * The TimeStretchPitchScale class.
+ * The TimeStretchPitchScaleReader class.
  */
 
 #include "TimeStretchPitchScale.h"
@@ -33,7 +33,7 @@ using namespace RubberBand;
 AUD_NAMESPACE_BEGIN
 
 /**
- * This class reads from another reader and applies time stretching and pitch scaling.
+ * This class reads from another reader and applies time-stretching and pitch scaling.
  */
 class AUD_API TimeStretchPitchScaleReader : public EffectReader
 {
@@ -94,7 +94,7 @@ private:
 	RubberBandStretcher* m_stretcher;
 
 	/**
-	 * Whether to preserve the vocal formants for the stretcher
+	 * Whether to preserve the vocal formants for the stretcher.
 	 */
 	bool m_preserveFormant;
 
@@ -138,10 +138,16 @@ public:
 	void setTimeRatio(double timeRatio);
 
 	/**
-	 * Retrieves the pitch scale for the stretcher
+	 * Retrieves the pitch scale for the stretcher.
 	 * \return The current pitch scale value.
 	 */
 	double getPitchScale() const;
+
+	/**
+	 * Retrieves the formant preservation setting.
+	 * \return True if formant preservation is enabled. Otherwise, false.
+	 */
+	bool getPreserveFormant() const;
 
 	/**
 	 * Sets the pitch scale for the stretcher.
@@ -149,7 +155,7 @@ public:
 	void setPitchScale(double pitchScale);
 
 	/**
-	 * Sets the configuration for the stretcher
+	 * Sets the configuration for the stretcher.
 	 */
 	void configure(StretcherQualityOptions quality, bool preserveFormant);
 };

--- a/include/fx/TimeStretchPitchScaleReader.h
+++ b/include/fx/TimeStretchPitchScaleReader.h
@@ -91,7 +91,7 @@ private:
 	/**
 	 * Rubberband stretcher.
 	 */
-	RubberBandStretcher* m_stretcher;
+	std::unique_ptr<RubberBandStretcher> m_stretcher;
 
 	/**
 	 * Whether to preserve the vocal formants for the stretcher.
@@ -117,8 +117,6 @@ public:
 	 * \param preserveFormant Whether to preserve the vocal formants for the stretcher.
 	 */
 	TimeStretchPitchScaleReader(std::shared_ptr<IReader> reader, double timeRatio, double pitchScale, StretcherQualityOptions quality, bool preserveFormant);
-
-	~TimeStretchPitchScaleReader();
 
 	virtual void read(int& length, bool& eos, sample_t* buffer);
 

--- a/src/fx/TimeStretchPitchScale.cpp
+++ b/src/fx/TimeStretchPitchScale.cpp
@@ -20,15 +20,15 @@
 
 AUD_NAMESPACE_BEGIN
 
-TimeStretchPitchScale::TimeStretchPitchScale(std::shared_ptr<ISound> sound, double timeRatio, double pitchScale, StretcherQualityOptions quality) :
-    Effect(sound), m_timeRatio(timeRatio), m_pitchScale(pitchScale), m_quality(quality)
+TimeStretchPitchScale::TimeStretchPitchScale(std::shared_ptr<ISound> sound, double timeRatio, double pitchScale, StretcherQualityOptions quality, bool preserveFormant) :
+    Effect(sound), m_timeRatio(timeRatio), m_pitchScale(pitchScale), m_quality(quality), m_preserveFormant(preserveFormant)
 
 {
 }
 
 std::shared_ptr<IReader> TimeStretchPitchScale::createReader()
 {
-	return std::shared_ptr<IReader>(new TimeStretchPitchScaleReader(getReader(), m_timeRatio, m_pitchScale, m_quality));
+	return std::shared_ptr<IReader>(new TimeStretchPitchScaleReader(getReader(), m_timeRatio, m_pitchScale, m_quality, m_preserveFormant));
 }
 
 double TimeStretchPitchScale::getTimeRatio() const
@@ -41,4 +41,8 @@ double TimeStretchPitchScale::getPitchScale() const
 	return m_pitchScale;
 }
 
+bool TimeStretchPitchScale::getPreserveFormant() const
+{
+	return m_preserveFormant;
+}
 AUD_NAMESPACE_END

--- a/src/fx/TimeStretchPitchScale.cpp
+++ b/src/fx/TimeStretchPitchScale.cpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2009-2025 Jörg Müller
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#include "fx/TimeStretchPitchScale.h"
+
+#include "fx/TimeStretchPitchScaleReader.h"
+
+AUD_NAMESPACE_BEGIN
+
+TimeStretchPitchScale::TimeStretchPitchScale(std::shared_ptr<ISound> sound, double timeRatio, double pitchScale, StretcherQualityOptions quality) :
+    Effect(sound), m_timeRatio(timeRatio), m_pitchScale(pitchScale), m_quality(quality)
+
+{
+}
+
+std::shared_ptr<IReader> TimeStretchPitchScale::createReader()
+{
+	return std::shared_ptr<IReader>(new TimeStretchPitchScaleReader(getReader(), m_timeRatio, m_pitchScale, m_quality));
+}
+
+double TimeStretchPitchScale::getTimeRatio() const
+{
+	return m_timeRatio;
+}
+
+double TimeStretchPitchScale::getPitchScale() const
+{
+	return m_pitchScale;
+}
+
+AUD_NAMESPACE_END

--- a/src/fx/TimeStretchPitchScale.cpp
+++ b/src/fx/TimeStretchPitchScale.cpp
@@ -20,7 +20,7 @@
 
 AUD_NAMESPACE_BEGIN
 
-TimeStretchPitchScale::TimeStretchPitchScale(std::shared_ptr<ISound> sound, double timeRatio, double pitchScale, StretcherQualityOptions quality, bool preserveFormant) :
+TimeStretchPitchScale::TimeStretchPitchScale(std::shared_ptr<ISound> sound, double timeRatio, double pitchScale, StretcherQualityOption quality, bool preserveFormant) :
     Effect(sound), m_timeRatio(timeRatio), m_pitchScale(pitchScale), m_quality(quality), m_preserveFormant(preserveFormant)
 
 {

--- a/src/fx/TimeStretchPitchScaleReader.cpp
+++ b/src/fx/TimeStretchPitchScaleReader.cpp
@@ -27,25 +27,34 @@ AUD_NAMESPACE_BEGIN
 
 TimeStretchPitchScaleReader::TimeStretchPitchScaleReader(std::shared_ptr<IReader> reader, double timeRatio, double pitchScale, StretcherQualityOption quality,
                                                          bool preserveFormant) :
-    EffectReader(reader),
-    m_timeRatio(timeRatio),
-    m_pitchScale(pitchScale),
-    m_position(0),
-    m_length(0),
-    m_quality(quality),
-    m_finishedReader(false),
-    m_input(reader->getSpecs().channels),
-    m_processData(reader->getSpecs().channels),
-    m_output(reader->getSpecs().channels),
-    m_retrieveData(reader->getSpecs().channels)
+    EffectReader(reader), m_position(0), m_finishedReader(false), m_channelData(reader->getSpecs().channels), m_deinterleaved(reader->getSpecs().channels)
 {
 	if (pitchScale < 1.0 / 256.0 || pitchScale > 256.0)
 		AUD_THROW(StateException, "The pitch scale must be between 1/256 and 256");
 
 	if (timeRatio < 1.0 / 256.0 || timeRatio > 256.0)
 		AUD_THROW(StateException, "The time-stretch ratio must be between 1/256 and 256");
-		
-	configure(quality, preserveFormant);
+
+	RubberBandStretcher::Options options = RubberBandStretcher::OptionProcessRealTime | RubberBandStretcher::OptionEngineFiner | RubberBandStretcher::OptionChannelsTogether;
+
+	switch(quality)
+	{
+	case StretcherQualityOption::HIGH:
+		options |= RubberBandStretcher::OptionPitchHighQuality;
+		break;
+	case StretcherQualityOption::FAST:
+		options |= RubberBandStretcher::OptionPitchHighSpeed;
+		options |= RubberBandStretcher::OptionWindowShort;
+		break;
+	case StretcherQualityOption::CONSISTENT:
+		options |= RubberBandStretcher::OptionPitchHighConsistency;
+		break;
+	default:
+		break;
+	}
+
+	options |= preserveFormant ? RubberBandStretcher::OptionFormantPreserved : RubberBandStretcher::OptionFormantShifted;
+	m_stretcher = std::make_unique<RubberBandStretcher>(m_reader->getSpecs().rate, m_reader->getSpecs().channels, options, timeRatio, pitchScale);
 }
 
 void TimeStretchPitchScaleReader::read(int& length, bool& eos, sample_t* buffer)
@@ -71,23 +80,22 @@ void TimeStretchPitchScaleReader::read(int& length, bool& eos, sample_t* buffer)
 			sample_t* buf = m_buffer.getBuffer();
 
 			m_reader->read(len, m_finishedReader, buf);
-			m_position += len;
 
 			// Deinterleave the input reader buffer for processing
 			for(int channel = 0; channel < channels; channel++)
 			{
-				m_input[channel].assureSize(len * sizeof(sample_t));
-				sample_t* channelBuf = m_input[channel].getBuffer();
+				m_deinterleaved[channel].assureSize(len * sizeof(sample_t));
+				sample_t* channelBuf = m_deinterleaved[channel].getBuffer();
 
 				for(int i = 0; i < len; i++)
 				{
 					channelBuf[i] = buf[i * channels + channel];
 				}
 
-				m_processData[channel] = channelBuf;
+				m_channelData[channel] = channelBuf;
 			}
 
-			m_stretcher->process(m_processData.data(), len, m_finishedReader);
+			m_stretcher->process(m_channelData.data(), len, m_finishedReader);
 		}
 
 		int available = m_stretcher->available();
@@ -105,16 +113,16 @@ void TimeStretchPitchScaleReader::read(int& length, bool& eos, sample_t* buffer)
 
 		for(int channel = 0; channel < channels; channel++)
 		{
-			m_output[channel].assureSize(readAmt * sizeof(sample_t));
-			m_retrieveData[channel] = m_output[channel].getBuffer();
+			m_deinterleaved[channel].assureSize(readAmt * sizeof(sample_t));
+			m_channelData[channel] = m_deinterleaved[channel].getBuffer();
 		}
 
-		m_stretcher->retrieve(m_retrieveData.data(), readAmt);
+		m_stretcher->retrieve(m_channelData.data(), readAmt);
 
 		// Interleave the retrieved data into the buffer
 		for(int channel = 0; channel < channels; channel++)
 		{
-			sample_t* outputBuf = m_output[channel].getBuffer();
+			sample_t* outputBuf = m_deinterleaved[channel].getBuffer();
 			for(int i = 0; i < readAmt; i++)
 			{
 				buffer[(buf_position + i) * channels + channel] = outputBuf[i];
@@ -122,50 +130,42 @@ void TimeStretchPitchScaleReader::read(int& length, bool& eos, sample_t* buffer)
 		}
 
 		buf_position += readAmt;
-		m_length += readAmt;
 	}
 
 	length = buf_position;
+	m_position += length;
 	eos = m_stretcher->available() == -1;
 }
 
 double TimeStretchPitchScaleReader::getTimeRatio() const
 {
-	return m_timeRatio;
+	return m_stretcher->getTimeRatio();
 }
 
 void TimeStretchPitchScaleReader::setTimeRatio(double timeRatio)
 {
-	if(timeRatio >= 1.0 / 256.0 && timeRatio <= 256.0 && timeRatio != m_stretcher->getTimeRatio())
+	if(timeRatio >= 1.0 / 256.0 && timeRatio <= 256.0)
 	{
-		m_timeRatio = timeRatio;
 		m_stretcher->setTimeRatio(timeRatio);
 	}
 }
 
 double TimeStretchPitchScaleReader::getPitchScale() const
 {
-	return m_pitchScale;
+	return m_stretcher->getPitchScale();
 }
 
 void TimeStretchPitchScaleReader::setPitchScale(double pitchScale)
 {
-	if(pitchScale >= 1.0 / 256.0 && pitchScale <= 256.0 && pitchScale != m_stretcher->getPitchScale())
+	if(pitchScale >= 1.0 / 256.0 && pitchScale <= 256.0)
 	{
-		m_pitchScale = pitchScale;
 		m_stretcher->setPitchScale(pitchScale);
 	}
 }
 
-bool TimeStretchPitchScaleReader::getPreserveFormant() const
-{
-	return m_preserveFormant;
-}
-
 void TimeStretchPitchScaleReader::seek(int position)
 {
-	m_length = 0;
-	m_reader->seek(position);
+	m_reader->seek(int(position / getTimeRatio()));
 	m_finishedReader = false;
 	m_stretcher->reset();
 	m_position = position;
@@ -173,43 +173,12 @@ void TimeStretchPitchScaleReader::seek(int position)
 
 int TimeStretchPitchScaleReader::getLength() const
 {
-	return m_length;
+	return m_reader->getLength() * getTimeRatio();
 }
 
 int TimeStretchPitchScaleReader::getPosition() const
 {
 	return m_position;
-}
-
-void TimeStretchPitchScaleReader::configure(StretcherQualityOption quality, bool preserveFormant)
-{
-	if(m_stretcher && quality == m_quality && preserveFormant == m_preserveFormant)
-		return;
-
-	m_stretcher.reset();
-
-	RubberBandStretcher::Options options = RubberBandStretcher::OptionProcessRealTime | RubberBandStretcher::OptionEngineFiner | RubberBandStretcher::OptionChannelsTogether;
-
-	switch(quality)
-	{
-	case StretcherQualityOption::HIGH:
-		options |= RubberBandStretcher::OptionPitchHighQuality;
-		break;
-	case StretcherQualityOption::FAST:
-		options |= RubberBandStretcher::OptionPitchHighSpeed;
-		options |= RubberBandStretcher::OptionWindowShort;
-		break;
-	case StretcherQualityOption::CONSISTENT:
-		options |= RubberBandStretcher::OptionPitchHighConsistency;
-		break;
-	default:
-		break;
-	}
-
-	options |= preserveFormant ? RubberBandStretcher::OptionFormantPreserved : RubberBandStretcher::OptionFormantShifted;
-	m_stretcher = std::make_unique<RubberBandStretcher>(m_reader->getSpecs().rate, m_reader->getSpecs().channels, options, m_timeRatio, m_pitchScale);
-	m_quality = quality;
-	m_preserveFormant = preserveFormant;
 }
 
 AUD_NAMESPACE_END

--- a/src/fx/TimeStretchPitchScaleReader.cpp
+++ b/src/fx/TimeStretchPitchScaleReader.cpp
@@ -150,6 +150,11 @@ void TimeStretchPitchScaleReader::setPitchScale(double pitchScale)
 	}
 }
 
+bool TimeStretchPitchScaleReader::getPreserveFormant() const
+{
+	return m_preserveFormant;
+}
+
 void TimeStretchPitchScaleReader::seek(int position)
 {
 	m_length = 0;

--- a/src/fx/TimeStretchPitchScaleReader.cpp
+++ b/src/fx/TimeStretchPitchScaleReader.cpp
@@ -25,14 +25,14 @@ using namespace RubberBand;
 
 AUD_NAMESPACE_BEGIN
 
-TimeStretchPitchScaleReader::TimeStretchPitchScaleReader(std::shared_ptr<IReader> reader, double timeRatio, double pitchScale, StretcherQualityOptions quality,
+TimeStretchPitchScaleReader::TimeStretchPitchScaleReader(std::shared_ptr<IReader> reader, double timeRatio, double pitchScale, StretcherQualityOption quality,
                                                          bool preserveFormant) :
     EffectReader(reader),
     m_timeRatio(timeRatio),
     m_pitchScale(pitchScale),
     m_position(0),
     m_length(0),
-    m_quality(-1),
+    m_quality(quality),
     m_finishedReader(false),
     m_input(reader->getSpecs().channels),
     m_processData(reader->getSpecs().channels),
@@ -181,68 +181,32 @@ int TimeStretchPitchScaleReader::getPosition() const
 	return m_position;
 }
 
-void TimeStretchPitchScaleReader::configure(StretcherQualityOptions quality, bool preserveFormant)
+void TimeStretchPitchScaleReader::configure(StretcherQualityOption quality, bool preserveFormant)
 {
-	if(quality == m_quality && preserveFormant == m_preserveFormant)
+	if(m_stretcher && quality == m_quality && preserveFormant == m_preserveFormant)
 		return;
 
 	m_stretcher.reset();
-	RubberBandStretcher::Options options = RubberBandStretcher::OptionProcessRealTime;
 
-	options |= (quality & StretcherQualityOption::HIGH) ? RubberBandStretcher::OptionEngineFiner : RubberBandStretcher::OptionEngineFaster;
+	RubberBandStretcher::Options options = RubberBandStretcher::OptionProcessRealTime | RubberBandStretcher::OptionEngineFiner | RubberBandStretcher::OptionChannelsTogether;
+
+	switch(quality)
+	{
+	case StretcherQualityOption::HIGH:
+		options |= RubberBandStretcher::OptionPitchHighQuality;
+		break;
+	case StretcherQualityOption::FAST:
+		options |= RubberBandStretcher::OptionPitchHighSpeed;
+		options |= RubberBandStretcher::OptionWindowShort;
+		break;
+	case StretcherQualityOption::CONSISTENT:
+		options |= RubberBandStretcher::OptionPitchHighConsistency;
+		break;
+	default:
+		break;
+	}
 
 	options |= preserveFormant ? RubberBandStretcher::OptionFormantPreserved : RubberBandStretcher::OptionFormantShifted;
-
-	RubberBandStretcher::Option windowOption = RubberBandStretcher::OptionWindowStandard;
-
-	if(quality & StretcherQualityOption::CRISP_0)
-	{
-		options |= RubberBandStretcher::OptionTransientsSmooth;
-		options |= RubberBandStretcher::OptionPhaseIndependent;
-		options |= RubberBandStretcher::OptionDetectorCompound;
-		windowOption = RubberBandStretcher::OptionWindowLong;
-	}
-	else if(quality & StretcherQualityOption::CRISP_1)
-	{
-		options |= RubberBandStretcher::OptionTransientsCrisp;
-		options |= RubberBandStretcher::OptionPhaseIndependent;
-		options |= RubberBandStretcher::OptionDetectorSoft;
-		windowOption = RubberBandStretcher::OptionWindowLong;
-	}
-	else if(quality & StretcherQualityOption::CRISP_2)
-	{
-		options |= RubberBandStretcher::OptionTransientsSmooth;
-		options |= RubberBandStretcher::OptionPhaseIndependent;
-		options |= RubberBandStretcher::OptionDetectorCompound;
-	}
-	else if(quality & StretcherQualityOption::CRISP_3)
-	{
-		options |= RubberBandStretcher::OptionTransientsSmooth;
-		options |= RubberBandStretcher::OptionPhaseLaminar;
-		options |= RubberBandStretcher::OptionDetectorCompound;
-	}
-	else if(quality & StretcherQualityOption::CRISP_4)
-	{
-		options |= RubberBandStretcher::OptionTransientsMixed;
-		options |= RubberBandStretcher::OptionPhaseLaminar;
-		options |= RubberBandStretcher::OptionDetectorCompound;
-	}
-	else if(quality & StretcherQualityOption::CRISP_5)
-	{
-		options |= RubberBandStretcher::OptionTransientsCrisp;
-		options |= RubberBandStretcher::OptionPhaseLaminar;
-		options |= RubberBandStretcher::OptionDetectorCompound;
-	}
-	else if(quality & StretcherQualityOption::CRISP_6)
-	{
-		options |= RubberBandStretcher::OptionTransientsCrisp;
-		options |= RubberBandStretcher::OptionPhaseIndependent;
-		options |= RubberBandStretcher::OptionDetectorCompound;
-		windowOption = RubberBandStretcher::OptionWindowShort;
-	}
-
-	options |= windowOption;
-
 	m_stretcher = std::make_unique<RubberBandStretcher>(m_reader->getSpecs().rate, m_reader->getSpecs().channels, options, m_timeRatio, m_pitchScale);
 	m_quality = quality;
 	m_preserveFormant = preserveFormant;

--- a/src/fx/TimeStretchPitchScaleReader.cpp
+++ b/src/fx/TimeStretchPitchScaleReader.cpp
@@ -1,0 +1,257 @@
+/*******************************************************************************
+ * Copyright 2009-2025 Jörg Müller
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#include "fx/TimeStretchPitchScaleReader.h"
+
+#include <iostream>
+
+#include "IReader.h"
+
+#include "util/Buffer.h"
+
+using namespace RubberBand;
+
+AUD_NAMESPACE_BEGIN
+
+TimeStretchPitchScaleReader::TimeStretchPitchScaleReader(std::shared_ptr<IReader> reader, double timeRatio, double pitchScale, StretcherQualityOptions quality) :
+    EffectReader(reader),
+    m_timeRatio(timeRatio),
+    m_pitchScale(pitchScale),
+    m_position(0),
+    m_length(0),
+    m_quality(-1),
+    m_finishedReader(false),
+    m_input(reader->getSpecs().channels),
+    m_processData(reader->getSpecs().channels),
+    m_output(reader->getSpecs().channels),
+    m_retrieveData(reader->getSpecs().channels)
+{
+	configure(quality);
+}
+
+void TimeStretchPitchScaleReader::read(int& length, bool& eos, sample_t* buffer)
+{
+	if(length == 0)
+		return;
+
+	int samplesize = AUD_SAMPLE_SIZE(m_reader->getSpecs());
+
+	int channels = m_reader->getSpecs().channels;
+	int len;
+	sample_t* buf;
+
+	// Read until we have enough samples to retrieve
+	int available = m_stretcher->available();
+	while(available < length && !m_finishedReader)
+	{
+		// size_t need = m_stretcher->getSamplesRequired();
+		// if (need == 0) break;
+
+		// Note for the V3 engine, the needed samples can be 0 sometimes and it breaks out of the loop too early before getting the necessary length for the buffer
+		// For now, choose the block size process size to be 1024.
+		// It's also actually faster too than to always use getSamplesRequired();
+
+		len = 1024;
+
+		m_buffer.assureSize(len * samplesize);
+		buf = m_buffer.getBuffer();
+
+		m_reader->read(len, m_finishedReader, buf);
+		
+
+		for(int channel = 0; channel < channels; channel++)
+		{
+			m_input[channel].assureSize(len * sizeof(sample_t));
+			sample_t* channelBuf = m_input[channel].getBuffer();
+			for(int i = 0; i < len; i++)
+			{
+				channelBuf[i] = buf[i * channels + channel];
+			}
+		}
+
+		for(int channel = 0; channel < channels; channel++)
+		{
+			m_processData[channel] = m_input[channel].getBuffer();
+		}
+
+		m_stretcher->process(m_processData.data(), len, m_finishedReader);
+
+		available = m_stretcher->available();
+	}
+
+	if(available <= 0)
+	{
+		length = 0;
+		return;
+	}
+
+	int readAmt = std::min(length, available);
+	length = readAmt;
+
+	for(int channel = 0; channel < channels; channel++)
+	{
+		m_output[channel].assureSize(readAmt * sizeof(sample_t));
+		m_retrieveData[channel] = m_output[channel].getBuffer();
+	}
+
+	size_t frameRetrieved = m_stretcher->retrieve(m_retrieveData.data(), readAmt);
+
+	// Interleave the retrieved data into buffer
+	for(int channel = 0; channel < channels; channel++)
+	{
+		sample_t* outputBuf = m_output[channel].getBuffer();
+		for(int i = 0; i < frameRetrieved; i++)
+		{
+			buffer[i * channels + channel] = outputBuf[i];
+		}
+	}
+
+	m_length += frameRetrieved;
+	m_position += frameRetrieved;
+
+	eos = m_stretcher->available() == -1;
+}
+
+double TimeStretchPitchScaleReader::getTimeRatio() const
+{
+	return m_timeRatio;
+}
+
+void TimeStretchPitchScaleReader::setTimeRatio(double timeRatio)
+{
+	if(timeRatio >= 1.0 / 256.0 && timeRatio <= 256.0 && timeRatio != m_stretcher->getTimeRatio())
+	{
+		m_timeRatio = timeRatio;
+		m_stretcher->setTimeRatio(timeRatio);
+		// m_stretcher->reset();
+	}
+}
+
+double TimeStretchPitchScaleReader::getPitchScale() const
+{
+	return m_pitchScale;
+}
+
+void TimeStretchPitchScaleReader::setPitchScale(double pitchScale)
+{
+	if(pitchScale >= 1.0 / 256.0 && pitchScale <= 256.0 && pitchScale != m_stretcher->getPitchScale())
+	{
+		m_pitchScale = pitchScale;
+		m_stretcher->setPitchScale(pitchScale);
+		// m_stretcher->reset();
+	}
+}
+
+void TimeStretchPitchScaleReader::seek(int position)
+{
+	m_length = 0;
+	m_reader->seek(position);
+	m_finishedReader = false;
+	m_stretcher->reset();
+	m_position = position;
+}
+
+int TimeStretchPitchScaleReader::getLength() const
+{
+	return m_length;
+}
+
+int TimeStretchPitchScaleReader::getPosition() const
+{
+	return m_position;
+}
+
+TimeStretchPitchScaleReader::~TimeStretchPitchScaleReader()
+{
+	delete m_stretcher;
+}
+
+void TimeStretchPitchScaleReader::configure(StretcherQualityOptions quality)
+{
+	RubberBandStretcher::Options options = RubberBandStretcher::OptionProcessRealTime;
+
+	if(quality == m_quality)
+		return;
+
+	if(!m_stretcher)
+	{
+		delete m_stretcher;
+	}
+
+	if(quality & StretcherQualityOption::HIGH)
+	{
+		options |= RubberBandStretcher::OptionEngineFiner;
+	}
+	else
+	{
+		options |= RubberBandStretcher::OptionEngineFaster;
+	}
+
+	RubberBandStretcher::Option windowOption = RubberBandStretcher::OptionWindowStandard;
+
+	if(quality & StretcherQualityOption::CRISP_0)
+	{
+		options |= RubberBandStretcher::OptionTransientsSmooth;
+		options |= RubberBandStretcher::OptionPhaseIndependent;
+		options |= RubberBandStretcher::OptionDetectorCompound;
+		windowOption = RubberBandStretcher::OptionWindowLong;
+	}
+	else if(quality & StretcherQualityOption::CRISP_1)
+	{
+		options |= RubberBandStretcher::OptionTransientsCrisp;
+		options |= RubberBandStretcher::OptionPhaseIndependent;
+		options |= RubberBandStretcher::OptionDetectorSoft;
+		windowOption = RubberBandStretcher::OptionWindowLong;
+	}
+	else if(quality & StretcherQualityOption::CRISP_2)
+	{
+		options |= RubberBandStretcher::OptionTransientsSmooth;
+		options |= RubberBandStretcher::OptionPhaseIndependent;
+		options |= RubberBandStretcher::OptionDetectorCompound;
+	}
+	else if(quality & StretcherQualityOption::CRISP_3)
+	{
+		options |= RubberBandStretcher::OptionTransientsSmooth;
+		options |= RubberBandStretcher::OptionPhaseLaminar;
+		options |= RubberBandStretcher::OptionDetectorCompound;
+	}
+	else if(quality & StretcherQualityOption::CRISP_4)
+	{
+		options |= RubberBandStretcher::OptionTransientsMixed;
+		options |= RubberBandStretcher::OptionPhaseLaminar;
+		options |= RubberBandStretcher::OptionDetectorCompound;
+	}
+	else if(quality & StretcherQualityOption::CRISP_5)
+	{
+		options |= RubberBandStretcher::OptionTransientsCrisp;
+		options |= RubberBandStretcher::OptionPhaseLaminar;
+		options |= RubberBandStretcher::OptionDetectorCompound;
+	}
+	else if(quality & StretcherQualityOption::CRISP_6)
+	{
+		options |= RubberBandStretcher::OptionTransientsCrisp;
+		options |= RubberBandStretcher::OptionPhaseIndependent;
+		options |= RubberBandStretcher::OptionDetectorCompound;
+		windowOption = RubberBandStretcher::OptionWindowShort;
+	}
+
+	options |= windowOption;
+
+	m_stretcher = new RubberBandStretcher(m_reader->getSpecs().rate, m_reader->getSpecs().channels, options, m_timeRatio, m_pitchScale);
+	m_quality = quality;
+}
+
+AUD_NAMESPACE_END

--- a/src/fx/TimeStretchPitchScaleReader.cpp
+++ b/src/fx/TimeStretchPitchScaleReader.cpp
@@ -99,7 +99,7 @@ void TimeStretchPitchScaleReader::read(int& length, bool& eos, sample_t* buffer)
 
 		int readAmt = std::min(left, available);
 		if(readAmt == 0)
-			break;
+			continue;
 
 		left -= readAmt;
 
@@ -181,21 +181,12 @@ int TimeStretchPitchScaleReader::getPosition() const
 	return m_position;
 }
 
-TimeStretchPitchScaleReader::~TimeStretchPitchScaleReader()
-{
-	delete m_stretcher;
-}
-
 void TimeStretchPitchScaleReader::configure(StretcherQualityOptions quality, bool preserveFormant)
 {
 	if(quality == m_quality && preserveFormant == m_preserveFormant)
 		return;
 
-	if(m_stretcher)
-	{
-		delete m_stretcher;
-	}
-
+	m_stretcher.reset();
 	RubberBandStretcher::Options options = RubberBandStretcher::OptionProcessRealTime;
 
 	options |= (quality & StretcherQualityOption::HIGH) ? RubberBandStretcher::OptionEngineFiner : RubberBandStretcher::OptionEngineFaster;
@@ -252,7 +243,7 @@ void TimeStretchPitchScaleReader::configure(StretcherQualityOptions quality, boo
 
 	options |= windowOption;
 
-	m_stretcher = new RubberBandStretcher(m_reader->getSpecs().rate, m_reader->getSpecs().channels, options, m_timeRatio, m_pitchScale);
+	m_stretcher = std::make_unique<RubberBandStretcher>(m_reader->getSpecs().rate, m_reader->getSpecs().channels, options, m_timeRatio, m_pitchScale);
 	m_quality = quality;
 	m_preserveFormant = preserveFormant;
 }

--- a/src/fx/TimeStretchPitchScaleReader.cpp
+++ b/src/fx/TimeStretchPitchScaleReader.cpp
@@ -58,14 +58,7 @@ void TimeStretchPitchScaleReader::read(int& length, bool& eos, sample_t* buffer)
 	int available = m_stretcher->available();
 	while(available < length && !m_finishedReader)
 	{
-		// size_t need = m_stretcher->getSamplesRequired();
-		// if (need == 0) break;
-
-		// Note for the V3 engine, the needed samples can be 0 sometimes and it breaks out of the loop too early before getting the necessary length for the buffer
-		// For now, choose the block size process size to be 1024.
-		// It's also actually faster too than to always use getSamplesRequired();
-
-		len = 1024;
+		len = std::max(int(length / m_timeRatio), 1);
 
 		m_buffer.assureSize(len * samplesize);
 		buf = m_buffer.getBuffer();
@@ -92,7 +85,7 @@ void TimeStretchPitchScaleReader::read(int& length, bool& eos, sample_t* buffer)
 
 		available = m_stretcher->available();
 	}
-
+	
 	if(available <= 0)
 	{
 		length = 0;


### PR DESCRIPTION
Part 1 of splitting up https://github.com/neXyon/audaspace/pull/51, which is adding the TimeStretchPitchScale effect

Small things to do before is ready:

- [x] Remove references to padAmount and dropAmount for TimeStretchPitchScale
- [x]  Add formant preserving option similar to https://hg.sr.ht/~breakfastquay/rubberband-qt-example/browse/src/Processor.cpp?rev=tip
- [x] Make the number of input samples depend on the output and time-stretch