### PR TITLE
Implemented a new Compressor effect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ set(SRC
 	src/fx/VolumeStorage.cpp
 	src/fx/Echo.cpp
 	src/fx/EchoReader.cpp
+	src/fx/Compressor.cpp
+	src/fx/CompressorReader.cpp
 	src/generator/Sawtooth.cpp
 	src/generator/SawtoothReader.cpp
 	src/generator/Silence.cpp
@@ -210,6 +212,8 @@ set(PUBLIC_HDR
 	include/fx/VolumeStorage.h
 	include/fx/Echo.h
 	include/fx/EchoReader.h
+	include/fx/Compressor.h
+	include/fx/CompressorReader.h
 	include/generator/Sawtooth.h
 	include/generator/SawtoothReader.h
 	include/generator/Silence.h

--- a/bindings/C/AUD_Sound.cpp
+++ b/bindings/C/AUD_Sound.cpp
@@ -798,6 +798,18 @@ AUD_API AUD_Sound* AUD_Sound_Echo(AUD_Sound* sound, float delay, float feedback,
 	}
 }
 
+AUD_API AUD_Sound* AUD_Sound_Compress(AUD_Sound* sound, float threshold, float ratio, float attack, float release, float makeupGain, float kneeWidth, float lookahead){
+	assert(sound);
+	try
+	{
+		return new AUD_Sound(new Compressor(*sound, threshold, ratio, attack, release, makeupGain, kneeWidth, lookahead));
+	}
+	catch(Exception&)
+	{
+		return nullptr;
+	}
+}
+
 AUD_API AUD_Sound* AUD_Sound_equalize(AUD_Sound* sound, float *definition, int size, float maxFreqEq, int sizeConversion)
 {
 	assert(sound);

--- a/bindings/C/AUD_Sound.h
+++ b/bindings/C/AUD_Sound.h
@@ -405,6 +405,20 @@ extern AUD_API AUD_Sound* AUD_Sound_mutable(AUD_Sound* sound);
      */
 extern AUD_API AUD_Sound* AUD_Sound_Echo(AUD_Sound* sound, float delay, float feedback, float mix, bool resetBuffer);
 
+/**
+ * Adds Compressor effect to the sound.
+ * \param sound The handle of the sound.
+ * \param threshold The threshold in dB.
+ * \param ratio The compression ratio.
+ * \param attack The attack time in seconds.
+ * \param release The release time in seconds.
+ * \param makeupGain The makeup gain in dB.
+ * \param kneeWidth The knee width in dB.
+ * \param lookahead The lookahead time in seconds.
+ * \return A handle of the compressed sound.
+ */
+extern AUD_API AUD_Sound* AUD_Sound_Compress(AUD_Sound* sound, float threshold, float ratio, float attack, float release, float makeupGain, float kneeWidth, float lookahead);
+
 #ifdef WITH_CONVOLUTION
 	extern AUD_API AUD_Sound* AUD_Sound_Convolver(AUD_Sound* sound, AUD_ImpulseResponse* filter, AUD_ThreadPool* threadPool);
 	extern AUD_API AUD_Sound* AUD_Sound_Binaural(AUD_Sound* sound, AUD_HRTF* hrtfs, AUD_Source* source, AUD_ThreadPool* threadPool);

--- a/include/fx/Compressor.h
+++ b/include/fx/Compressor.h
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright 2015-2025 Ketsebaot Gizachew
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#pragma once
+
+#include "fx/Effect.h"
+
+AUD_NAMESPACE_BEGIN
+
+/*
+ * This effect compresses the audio signal. based on the specified threshold and ratio and other parameters.
+ */
+
+class AUD_API Compressor : public Effect
+{
+private:
+	float m_threshold;
+	float m_ratio;
+	float m_attack;
+	float m_release;
+	float m_makeupGain;
+	float m_kneeWidth;
+	float m_lookaheadMs;
+
+	// delete copy constructor and assignment operator
+	Compressor(const Compressor&) = delete;
+	Compressor& operator=(const Compressor&) = delete;
+
+public:
+	/**
+	 * @brief Construct a new Compressor object
+	 *
+	 * @param threshold Threshold level in dBFS (e.g., -18.0)
+	 * @param ratio Compression ratio (e.g., 4.0 means 4:1)
+	 * @param attack Attack time in milliseconds
+	 * @param release Release time in milliseconds
+	 * @param gain Output gain in dB
+	 * @param kneeWidth Knee width in dB
+	 * @param lookaheadMs Lookahead time in milliseconds
+	 */
+	Compressor(std::shared_ptr<ISound> sound, float threshold, float ratio, float attack, float release, float makeupGain, float kneeWidth, float lookaheadMs);
+
+	float getThreshold() const;
+
+	float getRatio() const;
+
+	float getAttack() const;
+
+	float getRelease() const;
+
+	float getGain() const;
+
+	float getLookahead() const;
+
+	virtual std::shared_ptr<IReader> createReader();
+};
+
+AUD_NAMESPACE_END

--- a/include/fx/CompressorReader.h
+++ b/include/fx/CompressorReader.h
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright 2015-2025 Ketsebaot Gizachew
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#pragma once
+
+#include <vector>
+
+#include "fx/EffectReader.h"
+#include "util/Buffer.h"
+
+AUD_NAMESPACE_BEGIN
+
+class CompressorReader : public EffectReader
+{
+public:
+    // All time units are now in seconds, gains are ratios (1.0 = 0 dB)
+    CompressorReader(std::shared_ptr<IReader> reader, float thresholdRatio, float ratio, float attackSec, float releaseSec, float makeupGainRatio, float kneeWidthDb, float lookaheadSec);
+    virtual void read(int& length, bool& eos, sample_t* buffer) override;
+
+private:
+    float m_thresholdRatio;      // Threshold as ratio (1.0 = 0 dB)
+    float m_ratio;               // Compression ratio
+    float m_attackSec;           // Attack time in seconds
+    float m_releaseSec;          // Release time in seconds
+    float m_makeupGainRatio;     // Makeup gain as ratio (1.0 = 0 dB)
+    float m_kneeWidthDb;         // Knee width in dB
+    int m_lookaheadSamples;      // Lookahead in samples
+    aud::Buffer m_delayBuffer;
+    aud::Buffer m_sidechainBuffer;
+    int m_delayBufferWritePos;
+
+    float m_attackCoeff;
+    float m_releaseCoeff;
+    std::vector<float> m_rmsState;
+
+    int m_channels;
+    int m_windowSize;
+    std::vector<float> m_envelope;
+
+    CompressorReader(const CompressorReader&) = delete;
+    CompressorReader& operator=(const CompressorReader&) = delete;
+};
+
+AUD_NAMESPACE_END

--- a/src/fx/Compressor.cpp
+++ b/src/fx/Compressor.cpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright 2015-2025 Ketsebaot Gizachew
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#include "fx/Compressor.h"
+
+#include "fx/CompressorReader.h"
+
+AUD_NAMESPACE_BEGIN
+
+Compressor::Compressor(std::shared_ptr<ISound> sound, float threshold, float ratio, float attack, float release, float makeupGain, float kneeWidth, float lookaheadMs) :
+    Effect(sound), m_threshold(threshold), m_ratio(ratio), m_attack(attack), m_release(release), m_makeupGain(makeupGain), m_kneeWidth(kneeWidth), m_lookaheadMs(lookaheadMs)
+{
+}
+
+float Compressor::getThreshold() const
+{
+	return m_threshold;
+}
+
+float Compressor::getRatio() const
+{
+	return m_ratio;
+}
+
+float Compressor::getAttack() const
+{
+	return m_attack;
+}
+
+float Compressor::getRelease() const
+{
+	return m_release;
+}
+
+float Compressor::getGain() const
+{
+	return m_makeupGain;
+}
+
+std::shared_ptr<IReader> Compressor::createReader()
+{
+	// Implementation for creating a reader specific to the compressor effect
+	return std::shared_ptr<IReader>(new CompressorReader(m_sound->createReader(), m_threshold, m_ratio, m_attack, m_release, m_makeupGain, m_kneeWidth, m_lookaheadMs));
+}
+
+AUD_NAMESPACE_END

--- a/src/fx/CompressorReader.cpp
+++ b/src/fx/CompressorReader.cpp
@@ -1,0 +1,216 @@
+/*******************************************************************************
+ * Copyright 2015-2025 Ketsebaot Gizachew
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#include "fx/CompressorReader.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+AUD_NAMESPACE_BEGIN
+
+CompressorReader::CompressorReader(std::shared_ptr<IReader> reader,
+                                   float thresholdRatio,
+                                   float ratio,
+                                   float attackSec,
+                                   float releaseSec,
+                                   float makeupGainRatio,
+                                   float kneeWidthDb,
+                                   float lookaheadSec) :
+    EffectReader(reader),
+    m_thresholdRatio(thresholdRatio),
+    m_ratio(ratio),
+    m_attackSec(attackSec),
+    m_releaseSec(releaseSec),
+    m_makeupGainRatio(makeupGainRatio),
+    m_kneeWidthDb(kneeWidthDb)
+{
+  Specs specs = m_reader->getSpecs();
+  m_channels = specs.channels;
+  m_lookaheadSamples = 0;
+  m_delayBufferWritePos = 0;
+
+  // Envelope follower coefficients calculation
+  m_attackCoeff = std::exp(-1.0f / (m_attackSec * specs.rate));
+  m_releaseCoeff = std::exp(-1.0f / (m_releaseSec * specs.rate));
+
+  m_envelope.resize(m_channels, 0.0f);
+  m_rmsState.resize(m_channels, 0.0f);
+
+  if (lookaheadSec > 0.0f && m_channels > 0) {
+    m_lookaheadSamples = static_cast<int>(lookaheadSec * specs.rate);
+    if (m_lookaheadSamples > 0) {
+      // Buffer needs to be larger than lookahead to avoid read/write collision
+      int safeSize = (m_lookaheadSamples + 1024) * m_channels * sizeof(sample_t);
+      m_delayBuffer.assureSize(safeSize, 0.0f);
+    }
+  }
+}
+
+void CompressorReader::read(int &length, bool &eos, sample_t *buffer)
+{
+  if (m_lookaheadSamples > 0) {
+    // --- LOOKAHEAD PATH ---
+    m_reader->read(length, eos, buffer);
+
+    if (length == 0) {
+      return;
+    }
+
+    Specs specs = m_reader->getSpecs();
+    const int channels = specs.channels;
+    const int total_samples = length * channels;
+
+    float thresholdRatio = m_thresholdRatio;
+    float ratio = m_ratio;
+    float makeup = m_makeupGainRatio;
+    float kneeDb = m_kneeWidthDb;
+
+    if (m_rmsState.size() != channels) {
+      m_rmsState.assign(channels, 0.0f);
+    }
+    if (m_envelope.size() != channels) {
+      m_envelope.assign(channels, 0.0f);
+    }
+
+    float rms_coeff = std::exp(-1.0f / (0.02f * specs.rate));
+    float min_rms = 1e-12f;
+    float attack_coeff = m_attackCoeff;
+    float release_coeff = m_releaseCoeff;
+
+    sample_t *delayBuffer = m_delayBuffer.getBuffer();
+    int delayBufferSize = m_delayBuffer.getSize() / sizeof(sample_t);
+
+    for (int i = 0; i < total_samples; ++i) {
+      int ch = i % channels;
+      
+      float sample = buffer[i];
+
+      float sq = sample * sample;
+      m_rmsState[ch] = rms_coeff * m_rmsState[ch] + (1.0f - rms_coeff) * sq;
+      float detector = std::sqrt(std::max(m_rmsState[ch], min_rms));
+      float detector_db = 20.0f * log10(detector + min_rms);
+      float threshold_db = 20.0f * log10(thresholdRatio);
+      float kneestart = threshold_db - kneeDb / 2.0f;
+      float kneeend = threshold_db + kneeDb / 2.0f;
+      float gainReduction_db = 0.0f;
+
+      if (detector_db < kneestart) {
+        gainReduction_db = 0.0f;
+      }
+      else if (detector_db > kneeend) {
+        gainReduction_db = (detector_db - threshold_db) * (1.0f - 1.0f / ratio);
+      }
+      else {
+        float x = detector_db - kneestart;
+        float y = x * x / (2.0f * kneeDb);
+        gainReduction_db = y * (1.0f - 1.0f / ratio);
+      }
+
+      float env = m_envelope[ch];
+      if (gainReduction_db > env) {
+        env = attack_coeff * env + (1.0f - attack_coeff) * gainReduction_db;
+      }
+      else {
+        env = release_coeff * env + (1.0f - release_coeff) * gainReduction_db;
+      }
+      m_envelope[ch] = env;
+
+      int delayIndex = (m_delayBufferWritePos - m_lookaheadSamples * channels + delayBufferSize) %
+                       delayBufferSize;
+      float delayedSample = delayBuffer[delayIndex];
+
+      delayBuffer[m_delayBufferWritePos] = buffer[i];
+
+      float smoothedGainReduction = std::pow(10.0f, -env / 20.0f);
+      float gain = smoothedGainReduction * makeup;
+      buffer[i] = delayedSample * gain;
+
+      m_delayBufferWritePos = (m_delayBufferWritePos + 1) % delayBufferSize;
+    }
+  }
+  else {
+
+    m_reader->read(length, eos, buffer);
+    if (length == 0) {
+      return;
+    }
+
+    Specs specs = m_reader->getSpecs();
+    const int channels = specs.channels;
+    const int total_samples = length * channels;
+
+    float thresholdRatio = m_thresholdRatio;
+    float ratio = m_ratio;
+    float makeup = m_makeupGainRatio;
+    float kneeDb = m_kneeWidthDb;
+
+    if (m_rmsState.size() != channels) {
+      m_rmsState.assign(channels, 0.0f);
+    }
+    if (m_envelope.size() != channels) {
+      m_envelope.assign(channels, 0.0f);
+    }
+
+    float rms_coeff = std::exp(-1.0f / (0.02f * specs.rate));
+    float min_rms = 1e-12f;
+    float attack_coeff = m_attackCoeff;
+    float release_coeff = m_releaseCoeff;
+
+    for (int i = 0; i < total_samples; ++i) {
+      int ch = i % channels;
+      float sample = buffer[i];
+
+      float sq = sample * sample;
+      m_rmsState[ch] = rms_coeff * m_rmsState[ch] + (1.0f - rms_coeff) * sq;
+      float detector = std::sqrt(std::max(m_rmsState[ch], min_rms));
+      float detector_db = 20.0f * log10(detector + min_rms);
+      float threshold_db = 20.0f * log10(thresholdRatio);
+      float kneestart = threshold_db - kneeDb / 2.0f;
+      float kneeend = threshold_db + kneeDb / 2.0f;
+      float gainReduction_db = 0.0f;
+
+      if (detector_db < kneestart) {
+        gainReduction_db = 0.0f;
+      }
+      else if (detector_db > kneeend) {
+        gainReduction_db = (detector_db - threshold_db) * (1.0f - 1.0f / ratio);
+      }
+      else {
+        float x = detector_db - kneestart;
+        float y = x * x / (2.0f * kneeDb);
+        gainReduction_db = y * (1.0f - 1.0f / ratio);
+      }
+
+      float env = m_envelope[ch];
+      if (gainReduction_db > env) {
+        env = attack_coeff * env + (1.0f - attack_coeff) * gainReduction_db;
+      }
+      else {
+        env = release_coeff * env + (1.0f - release_coeff) * gainReduction_db;
+      }
+      m_envelope[ch] = env;
+
+      float smoothedGainReduction = std::pow(10.0f, -env / 20.0f);
+      float gain = smoothedGainReduction * makeup;
+      
+      buffer[i] = sample * gain;
+    }
+  }
+}
+
+AUD_NAMESPACE_END


### PR DESCRIPTION
Hello there nexyon ! 

This PR adds a new, from-scratch audio compressor.

**Core Features:**

*   **RMS Detection:** Measures average signal power for a smoother, more musical response
*   **Soft Knee:** Gradually introduces compression around the threshold for a less aggressive and more transparent effect.
*   **Lookahead:** Delays the audio path, allowing the detector to anticipate and control transients without artifacts.

---

### **Waveform Export From Blender Comparison in FLStudio**
exported from blender a new compressor modifier.
<img width="1280" height="954" alt="image" src="https://github.com/user-attachments/assets/76658136-181e-427b-8dd1-d83ce81ab19f" />

the one on the top shows the compressed export from blenders VSE in which you can see places where it was higher being tamed down and the lower ones get increased a bit.

### **Another Waveform more obvious preview**
<img width="1789" height="1008" alt="image" src="https://github.com/user-attachments/assets/ce033df9-da43-429c-aa1f-a9c0b4df99d9" />

Bottom one is compressed on this one

**Note:** I'm still new to audio programming, so I'm very open to feedback if anything about the results looks wrong or could be improved. 😊