### PR TITLE
Build: macOS: Fix bitwise operation enum type warning in Audaspace

### DIFF
--- a/plugins/coreaudio/CoreAudioDevice.cpp
+++ b/plugins/coreaudio/CoreAudioDevice.cpp
@@ -157,7 +157,7 @@ CoreAudioDevice::CoreAudioDevice(DeviceSpecs specs, int buffersize) : m_buffersi
 
 	stream_basic_description.mSampleRate = m_specs.rate;
 	stream_basic_description.mFormatID = kAudioFormatLinearPCM;
-	stream_basic_description.mFormatFlags |= kAudioFormatFlagsNativeEndian | kLinearPCMFormatFlagIsPacked;
+	stream_basic_description.mFormatFlags |= AudioFormatFlags(kAudioFormatFlagsNativeEndian) | AudioFormatFlags(kLinearPCMFormatFlagIsPacked);
 	stream_basic_description.mBytesPerPacket = stream_basic_description.mBytesPerFrame = AUD_DEVICE_SAMPLE_SIZE(m_specs);
 	stream_basic_description.mFramesPerPacket = 1;
 	stream_basic_description.mChannelsPerFrame = m_specs.channels;


### PR DESCRIPTION
This commit fixes the following warning:

```
<...>/blender/extern/audaspace/plugins/coreaudio/CoreAudioDevice.cpp:160:73: warning: bitwise operation between different enumeration types ('(unnamed enum at <...>/CoreAudioTypes.framework/Headers/CoreAudioBaseTypes.h:573:1)' and '(unnamed enum at <...>/CoreAudioTypes.framework/Headers/CoreAudioBaseTypes.h:522:1)') is deprecated [-Wdeprecated-anon-enum-enum-conversion]
  160 |         stream_basic_description.mFormatFlags |= kAudioFormatFlagsNativeEndian | kLinearPCMFormatFlagIsPacked;

```

This deprecation (and warning) is new in C++20. The issue came from macOS CoreAudio using an internal macro (CF_ENUM) to define anonymous enums with an underlying type, with the warning then being cause by both of these constants being part of different enums.

Fixed by adding an explict cast to the underlying type (AudioFormatFlags) before applying the bitwise operation.

Upstream Blender commit: https://projects.blender.org/blender/blender/commit/7f2d038adbfb51ac1f7e5fd2e2369bc828a73ade