### PR TITLE
PyDoc: Add constructor docstrings to aud types

### DIFF
--- a/bindings/python/PyAnimateableProperty.cpp
+++ b/bindings/python/PyAnimateableProperty.cpp
@@ -326,7 +326,13 @@ static PyGetSetDef AnimateableProperty_properties[] = {
     {nullptr} /* Sentinel */
 };
 
-PyDoc_STRVAR(M_aud_AnimateableProperty_doc, "An AnimateableProperty object stores an array of float values for animating sound properties (e.g. pan, volume, pitch-scale)");
+PyDoc_STRVAR(M_aud_AnimateableProperty_doc,
+	".. class:: AnimateableProperty(count, value=0.0, /)\n\n"
+	"   An AnimateableProperty object stores an array of float values for animating sound properties (e.g. pan, volume, pitch-scale).\n\n"
+	"   :arg count: The number of float values to store per frame.\n"
+	"   :type count: int\n"
+	"   :arg value: The initial value for all elements.\n"
+	"   :type value: float\n");
 
 // Note that AnimateablePropertyType name is already taken
 PyTypeObject AnimateablePropertyPyType = {

--- a/bindings/python/PyDevice.cpp
+++ b/bindings/python/PyDevice.cpp
@@ -711,9 +711,22 @@ static PyGetSetDef Device_properties[] = {
 };
 
 PyDoc_STRVAR(M_aud_Device_doc,
-			 "Device objects represent an audio output backend like OpenAL or "
+			 ".. class:: Device(type='', rate=48000.0, channels=2, format=36, buffer_size=1024, name='')\n\n"
+			 "   Device objects represent an audio output backend like OpenAL or "
 			 "SDL, but might also represent a file output or RAM buffer "
-			 "output.");
+			 "output.\n\n"
+			 "   :arg type: The device type. An empty string means the default device.\n"
+			 "   :type type: string\n"
+			 "   :arg rate: The sample rate in Hz.\n"
+			 "   :type rate: double\n"
+			 "   :arg channels: The number of channels.\n"
+			 "   :type channels: int\n"
+			 "   :arg format: The sample format.\n"
+			 "   :type format: int\n"
+			 "   :arg buffer_size: The size of the audio buffer in samples.\n"
+			 "   :type buffer_size: int\n"
+			 "   :arg name: The name of the device.\n"
+			 "   :type name: string\n");
 
 static PyTypeObject DeviceType = {
 	PyVarObject_HEAD_INIT(nullptr, 0)

--- a/bindings/python/PyDynamicMusic.cpp
+++ b/bindings/python/PyDynamicMusic.cpp
@@ -392,8 +392,11 @@ static PyGetSetDef DynamicMusic_properties[] = {
 };
 
 PyDoc_STRVAR(M_aud_DynamicMusic_doc,
-	"The DynamicMusic object allows to play music depending on a current scene, scene changes are managed by the class, with the possibility of custom transitions.\n"
-	"The default transition is a crossfade effect, and the default scene is silent and has id 0");
+	".. class:: DynamicMusic(device, /)\n\n"
+	"   The DynamicMusic object allows to play music depending on a current scene, scene changes are managed by the class, with the possibility of custom transitions.\n"
+	"   The default transition is a crossfade effect, and the default scene is silent and has id 0.\n\n"
+	"   :arg device: The device that will be used to play sounds.\n"
+	"   :type device: :class:`Device`\n");
 
 PyTypeObject DynamicMusicType = {
 	PyVarObject_HEAD_INIT(nullptr, 0)

--- a/bindings/python/PyHRTF.cpp
+++ b/bindings/python/PyHRTF.cpp
@@ -173,7 +173,8 @@ static PyMethodDef HRTF_methods[] = {
 };
 
 PyDoc_STRVAR(M_aud_HRTF_doc,
-	"An HRTF object represents a set of head related transfer functions as impulse responses. It's used for binaural sound");
+	".. class:: HRTF()\n\n"
+	"   An HRTF object represents a set of head related transfer functions as impulse responses. It's used for binaural sound.\n");
 
 PyTypeObject HRTFType = {
 	PyVarObject_HEAD_INIT(nullptr, 0)

--- a/bindings/python/PyImpulseResponse.cpp
+++ b/bindings/python/PyImpulseResponse.cpp
@@ -63,7 +63,10 @@ static PyMethodDef ImpulseResponse_methods[] = {
 };
 
 PyDoc_STRVAR(M_aud_ImpulseResponse_doc,
-	"An ImpulseResponse object represents a filter with which to convolve a sound.");
+	".. class:: ImpulseResponse(sound, /)\n\n"
+	"   An ImpulseResponse object represents a filter with which to convolve a sound.\n\n"
+	"   :arg sound: The sound to use as the impulse response.\n"
+	"   :type sound: :class:`Sound`\n");
 
 PyTypeObject ImpulseResponseType = {
 	PyVarObject_HEAD_INIT(nullptr, 0)

--- a/bindings/python/PyPlaybackManager.cpp
+++ b/bindings/python/PyPlaybackManager.cpp
@@ -316,7 +316,10 @@ static PyMethodDef PlaybackManager_methods[] = {
 };
 
 PyDoc_STRVAR(M_aud_PlaybackManager_doc,
-	"A PlabackManager object allows to easily control groups os sounds organized in categories.");
+	".. class:: PlaybackManager(device, /)\n\n"
+	"   A PlaybackManager object allows to easily control groups of sounds organized in categories.\n\n"
+	"   :arg device: The device that will be used to play sounds.\n"
+	"   :type device: :class:`Device`\n");
 
 PyTypeObject PlaybackManagerType = {
 	PyVarObject_HEAD_INIT(nullptr, 0)

--- a/bindings/python/PySequence.cpp
+++ b/bindings/python/PySequence.cpp
@@ -579,7 +579,16 @@ static PyGetSetDef Sequence_properties[] = {
 };
 
 PyDoc_STRVAR(M_aud_Sequence_doc,
-			 "This sound represents sequenced entries to play a sound sequence.");
+			 ".. class:: Sequence(channels=2, rate=48000.0, fps=30.0, muted=False)\n\n"
+			 "   This sound represents sequenced entries to play a sound sequence.\n\n"
+			 "   :arg channels: The number of channels.\n"
+			 "   :type channels: int\n"
+			 "   :arg rate: The sample rate in Hz.\n"
+			 "   :type rate: double\n"
+			 "   :arg fps: The frames per second of the sequence.\n"
+			 "   :type fps: float\n"
+			 "   :arg muted: Whether the sequence is muted.\n"
+			 "   :type muted: bool\n");
 
 extern PyTypeObject SoundType;
 

--- a/bindings/python/PySound.cpp
+++ b/bindings/python/PySound.cpp
@@ -2171,10 +2171,16 @@ static PyGetSetDef Sound_properties[] = {
 };
 
 PyDoc_STRVAR(M_aud_Sound_doc,
-			 "Sound objects are immutable and represent a sound that can be "
+			 ".. class:: Sound(filename, stream=0)\n\n"
+			 "   Sound objects are immutable and represent a sound that can be "
 			 "played simultaneously multiple times. They are called factories "
 			 "because they create reader objects internally that are used for "
-			 "playback.");
+			 "playback.\n\n"
+			 "   :arg filename: Path of the file.\n"
+			 "   :type filename: string\n"
+			 "   :arg stream: The index of the audio stream within the file if it\n"
+			 "      contains multiple audio streams, 0 by default.\n"
+			 "   :type stream: int\n");
 
 PyTypeObject SoundType = {
 	PyVarObject_HEAD_INIT(nullptr, 0)

--- a/bindings/python/PySource.cpp
+++ b/bindings/python/PySource.cpp
@@ -186,7 +186,14 @@ static PyGetSetDef Source_properties[] = {
 };
 
 PyDoc_STRVAR(M_aud_Source_doc,
-	"The source object represents the source position of a binaural sound.");
+	".. class:: Source(azimuth, elevation, distance, /)\n\n"
+	"   The source object represents the source position of a binaural sound.\n\n"
+	"   :arg azimuth: The azimuth angle in degrees.\n"
+	"   :type azimuth: float\n"
+	"   :arg elevation: The elevation angle in degrees.\n"
+	"   :type elevation: float\n"
+	"   :arg distance: The distance of the source.\n"
+	"   :type distance: float\n");
 
 PyTypeObject SourceType = {
 	PyVarObject_HEAD_INIT(nullptr, 0)

--- a/bindings/python/PyThreadPool.cpp
+++ b/bindings/python/PyThreadPool.cpp
@@ -60,7 +60,10 @@ static PyMethodDef ThreadPool_methods[] = {
 };
 
 PyDoc_STRVAR(M_aud_ThreadPool_doc,
-	"A ThreadPool is used to parallelize convolution efficiently.");
+	".. class:: ThreadPool(nThreads, /)\n\n"
+	"   A ThreadPool is used to parallelize convolution efficiently.\n\n"
+	"   :arg nThreads: The number of threads in the pool.\n"
+	"   :type nThreads: int\n");
 
 PyTypeObject ThreadPoolType = {
 	PyVarObject_HEAD_INIT(nullptr, 0)


### PR DESCRIPTION
All constructible Python types in the `aud` module were missing constructor docstrings, leaving their parameters undocumented in the API reference.

This PR adds `.. class::` docstrings with parameter descriptions to:
`Sound`, `Device`, `Sequence`, `AnimateableProperty`, `ThreadPool`, `Source`, `DynamicMusic`, `PlaybackManager`, `ImpulseResponse`, `HRTF`.

Used `/` for methods that use `PyArg_ParseTuple`.

Also fixed two typos in `PlaybackManager`'s existing docstring ("PlabackManager", "groups os sounds").

Also resolves issue in Blender docs - https://projects.blender.org/blender/blender/issues/155921