### PR TITLE
Build: macOS: Fix deprecated enum float comparison warning in Audaspace

### DIFF
--- a/plugins/coreaudio/CoreAudioDevice.cpp
+++ b/plugins/coreaudio/CoreAudioDevice.cpp
@@ -99,7 +99,7 @@ CoreAudioDevice::CoreAudioDevice(DeviceSpecs specs, int buffersize) : m_buffersi
 		specs.channels = CHANNELS_STEREO;
 	if(specs.format == FORMAT_INVALID)
 		specs.format = FORMAT_FLOAT32;
-	if(specs.rate == RATE_INVALID)
+	if(specs.rate == static_cast<SampleRate>(RATE_INVALID))
 		specs.rate = RATE_48000;
 
 	m_specs = specs;


### PR DESCRIPTION
Similarly to #67, this commit fixes the following warning:

```
[4046/7361] Building CXX object extern/audaspace/CMakeFiles/audaspace.dir/plugins/coreaudio/CoreAudioDevice.cpp.o <..>/extern/audaspace/plugins/coreaudio/CoreAudioDevice.cpp:102:16: warning: comparison of floating-point type 'SampleRate' (aka 'double') with enumeration type 'aud::DefaultSampleRate' is deprecated [-Wdeprecated-enum-float-conversion]
  102 |         if(specs.rate == RATE_INVALID)
      |            ~~~~~~~~~~ ^  ~~~~~~~~~~~~
```

Fixed by adding an explicit cast to the specs.rate type (SampleRate, typedefed to double).

Upstream Blender commit: https://projects.blender.org/blender/blender/commit/071e11382ccbd7b47550601eb3cd65633000755a