### PR TITLE
Mixdown, FileWriter: allow cancelation via callback

### DIFF
--- a/bindings/C/AUD_Special.cpp
+++ b/bindings/C/AUD_Special.cpp
@@ -270,7 +270,7 @@ AUD_API int AUD_readSound(AUD_Sound* sound, float* buffer, int length, int sampl
 	return length;
 }
 
-AUD_API int AUD_mixdown(AUD_Sound* sound, unsigned int start, unsigned int length, unsigned int buffersize, const char* filename, AUD_DeviceSpecs specs, AUD_Container format, AUD_Codec codec, unsigned int bitrate, AUD_ResampleQuality quality, void(*callback)(float, void*), void* data, char* error, size_t errorsize)
+AUD_API int AUD_mixdown(AUD_Sound* sound, unsigned int start, unsigned int length, unsigned int buffersize, const char* filename, AUD_DeviceSpecs specs, AUD_Container format, AUD_Codec codec, unsigned int bitrate, AUD_ResampleQuality quality, bool(*callback)(float, void*), void* data, char* error, size_t errorsize)
 {
 	try
 	{
@@ -295,7 +295,7 @@ AUD_API int AUD_mixdown(AUD_Sound* sound, unsigned int start, unsigned int lengt
 	}
 }
 
-AUD_API int AUD_mixdown_per_channel(AUD_Sound* sound, unsigned int start, unsigned int length, unsigned int buffersize, const char* filename, AUD_DeviceSpecs specs, AUD_Container format, AUD_Codec codec, unsigned int bitrate, AUD_ResampleQuality quality, void(*callback)(float, void*), void* data, char* error, size_t errorsize)
+AUD_API int AUD_mixdown_per_channel(AUD_Sound* sound, unsigned int start, unsigned int length, unsigned int buffersize, const char* filename, AUD_DeviceSpecs specs, AUD_Container format, AUD_Codec codec, unsigned int bitrate, AUD_ResampleQuality quality, bool(*callback)(float, void*), void* data, char* error, size_t errorsize)
 {
 	try
 	{

--- a/bindings/C/AUD_Special.h
+++ b/bindings/C/AUD_Special.h
@@ -72,7 +72,7 @@ extern AUD_API int AUD_readSound(AUD_Sound* sound, float* buffer, int length, in
  * \param codec The codec used for encoding the audio data.
  * \param bitrate The bitrate for encoding.
  * \param quality The resampling quality.
- * \param callback A callback function that is called periodically during mixdown, reporting progress if length > 0. Can be NULL.
+ * \param callback A callback function that is called periodically during mixdown, reporting progress if length > 0. Mixdown is canceled if the callback returns false. Can be NULL.
  * \param data Pass through parameter that is passed to the callback.
  * \param error String buffer to copy the error message to in case of failure.
  * \param errorsize The size of the error buffer.
@@ -82,7 +82,7 @@ extern AUD_API int AUD_mixdown(AUD_Sound* sound, unsigned int start, unsigned in
 							   unsigned int buffersize, const char* filename,
 							   AUD_DeviceSpecs specs, AUD_Container format,
 							   AUD_Codec codec, unsigned int bitrate, AUD_ResampleQuality quality,
-							   void(*callback)(float, void*), void* data, char* error, size_t errorsize);
+							   bool(*callback)(float, void*), void* data, char* error, size_t errorsize);
 
 /**
  * Mixes a sound down into multiple files.
@@ -96,7 +96,7 @@ extern AUD_API int AUD_mixdown(AUD_Sound* sound, unsigned int start, unsigned in
  * \param codec The codec used for encoding the audio data.
  * \param bitrate The bitrate for encoding.
  * \param quality The resampling quality.
- * \param callback A callback function that is called periodically during mixdown, reporting progress if length > 0. Can be NULL.
+ * \param callback A callback function that is called periodically during mixdown, reporting progress if length > 0. Mixdown is canceled if the callback returns false. Can be NULL.
  * \param data Pass through parameter that is passed to the callback.
  * \param error String buffer to copy the error message to in case of failure.
  * \param errorsize The size of the error buffer.
@@ -106,7 +106,7 @@ extern AUD_API int AUD_mixdown_per_channel(AUD_Sound* sound, unsigned int start,
 										   unsigned int buffersize, const char* filename,
 										   AUD_DeviceSpecs specs, AUD_Container format,
 										   AUD_Codec codec, unsigned int bitrate, AUD_ResampleQuality quality,
-										   void(*callback)(float, void*), void* data, char* error, size_t errorsize);
+										   bool(*callback)(float, void*), void* data, char* error, size_t errorsize);
 
 /**
  * Opens a read device and prepares it for mixdown of the sound scene.

--- a/include/file/FileWriter.h
+++ b/include/file/FileWriter.h
@@ -63,7 +63,7 @@ public:
 	 * \param length How many samples should be transferred.
 	 * \param buffersize How many samples should be transferred at once.
 	 */
-	static void writeReader(std::shared_ptr<IReader> reader, std::shared_ptr<IWriter> writer, unsigned int length, unsigned int buffersize, void(*callback)(float, void*) = nullptr, void* data = nullptr);
+	static void writeReader(std::shared_ptr<IReader> reader, std::shared_ptr<IWriter> writer, unsigned int length, unsigned int buffersize, bool(*callback)(float, void*) = nullptr, void* data = nullptr);
 
 	/**
 	 * Writes a reader to several writers.
@@ -72,7 +72,7 @@ public:
 	 * \param length How many samples should be transferred.
 	 * \param buffersize How many samples should be transferred at once.
 	 */
-	static void writeReader(std::shared_ptr<IReader> reader, std::vector<std::shared_ptr<IWriter> >& writers, unsigned int length, unsigned int buffersize, void(*callback)(float, void*) = nullptr, void* data = nullptr);
+	static void writeReader(std::shared_ptr<IReader> reader, std::vector<std::shared_ptr<IWriter> >& writers, unsigned int length, unsigned int buffersize, bool(*callback)(float, void*) = nullptr, void* data = nullptr);
 };
 
 AUD_NAMESPACE_END

--- a/src/file/FileWriter.cpp
+++ b/src/file/FileWriter.cpp
@@ -27,7 +27,7 @@ std::shared_ptr<IWriter> FileWriter::createWriter(const std::string &filename,De
 	return FileManager::createWriter(filename, specs, format, codec, bitrate);
 }
 
-void FileWriter::writeReader(std::shared_ptr<IReader> reader, std::shared_ptr<IWriter> writer, unsigned int length, unsigned int buffersize, void(*callback)(float, void*), void* data)
+void FileWriter::writeReader(std::shared_ptr<IReader> reader, std::shared_ptr<IWriter> writer, unsigned int length, unsigned int buffersize, bool(*callback)(float, void*), void* data)
 {
 	Buffer buffer(buffersize * AUD_SAMPLE_SIZE(writer->getSpecs()));
 	sample_t* buf = buffer.getBuffer();
@@ -59,12 +59,15 @@ void FileWriter::writeReader(std::shared_ptr<IReader> reader, std::shared_ptr<IW
 			float progress = -1;
 			if(length > 0)
 				progress = pos / float(length);
-			callback(progress, data);
+			if (!callback(progress, data))
+			{
+				break;
+			}
 		}
 	}
 }
 
-void FileWriter::writeReader(std::shared_ptr<IReader> reader, std::vector<std::shared_ptr<IWriter> >& writers, unsigned int length, unsigned int buffersize, void(*callback)(float, void*), void* data)
+void FileWriter::writeReader(std::shared_ptr<IReader> reader, std::vector<std::shared_ptr<IWriter> >& writers, unsigned int length, unsigned int buffersize, bool(*callback)(float, void*), void* data)
 {
 	Buffer buffer(buffersize * AUD_SAMPLE_SIZE(reader->getSpecs()));
 	Buffer buffer2(buffersize * sizeof(sample_t));
@@ -103,7 +106,10 @@ void FileWriter::writeReader(std::shared_ptr<IReader> reader, std::vector<std::s
 			float progress = -1;
 			if(length > 0)
 				progress = pos / float(length);
-			callback(progress, data);
+			if (!callback(progress, data))
+			{
+				break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
The mixdown functions (`AUD_mixdown` and `AUD_mixdown_per_channel`) can take an optional callback for progress report. This was originally for the possibility of supporting a progress bar in the Blender VSE when rendering audio (see
https://projects.blender.org/blender/blender/issues/80219).

This adds a possibility to the callback to tell the file writers that the process should be stopped. It is done by returning a boolean from the callback, where true means continue, and false means break/stop.

This is necessary to be able to cancel the audio rendering from the Blender UI so that a progress bar with cancel button can be presented to the user.

NOTE: I am currently working on a patch to add the progress bar to Blender side.
See: https://projects.blender.org/blender/blender/pulls/155623