### PR TITLE
Fix AnimateableProperty::writeConstantRange resulting in garbage values when resampling

### DIFF
--- a/include/sequence/AnimateableProperty.h
+++ b/include/sequence/AnimateableProperty.h
@@ -73,6 +73,7 @@ private:
 	AnimateableProperty& operator=(const AnimateableProperty&) = delete;
 
 	void AUD_LOCAL updateUnknownCache(int start, int end);
+	void AUD_LOCAL updateUnknownAfterWrite(int pos, int position, int count);
 
 public:
 	/**

--- a/src/sequence/AnimateableProperty.cpp
+++ b/src/sequence/AnimateableProperty.cpp
@@ -68,8 +68,18 @@ void AnimateableProperty::write(const float* data)
 
 void AnimateableProperty::writeConstantRange(const float* data, int position_start, int position_end)
 {
+	int pos = getSize() / (sizeof(float) * m_count);
+
 	assureSize(position_end * m_count * sizeof(float), true);
 	float* buffer = Buffer::getBuffer();
+	
+	// if we were not animated yet, use the new constant value as the
+	// first/default value to fill in the unknown parts
+	if (!m_isAnimated)
+	{
+		std::memcpy(buffer, data, m_count * sizeof(float));
+		pos = 0;
+	}
 
 	for(int i = position_start; i < position_end; i++)
 	{
@@ -77,6 +87,8 @@ void AnimateableProperty::writeConstantRange(const float* data, int position_sta
 	}
 
 	m_isAnimated = true;
+	
+	updateUnknownAfterWrite(pos, position_start, position_end - position_start);
 }
 
 void AnimateableProperty::write(const float* data, int position, int count)
@@ -95,7 +107,12 @@ void AnimateableProperty::write(const float* data, int position, int count)
 	float* buf = Buffer::getBuffer();
 
 	std::memcpy(buf + position * m_count, data, count * m_count * sizeof(float));
+	
+	updateUnknownAfterWrite(pos, position, count);
+}
 
+void AnimateableProperty::updateUnknownAfterWrite(int pos, int position, int count)
+{
 	// have to fill up space between?
 	if(pos < position)
 	{


### PR DESCRIPTION
Fixes Blender bug where sometimes having retimed sound strips would crash (https://projects.blender.org/blender/blender/issues/155719). Blender PR: https://projects.blender.org/blender/blender/pulls/159091

The issue seems to be this:
1. Sound strips that are retimed use `AnimateableProperty::writeConstantRange` to write their section of pitch property values.
2. However, unlike `AnimateableProperty::write`, the `writeConstantRange` was not updating or handling "unknown" ranges of the animated values! So they ended up being completely uninitialized/garbage.
3. Now later on, when pitch value is read through `AnimateableProperty::read`, it does a cubic filter. Which means one of the filter taps can read from the "unknown" portion of the buffer, with whatever garbage value happened to be there.
4. As a result, effective pitch can end up being "anything", including values really close to zero, or values really close to infinities.
5. The JOS resample reader is not particularly safe against overflowing integers when it divides by ratios derived from this garbage pitch. So it ends up having "how much to read" being e.g. "4 billion" due to integer overflows.
6. Hilarity ensues!

From what I can tell, the problem is "just" that the `writeConstantRange`, when it was added in Audaspace 1.5 (db2ff5807765d), did not have the bit that fills in unknown parts of the buffer to have "something sensible".